### PR TITLE
Replace puppetserver-ca gem with openvoxserver-ca

### DIFF
--- a/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
+++ b/resources/ext/build-scripts/mri-gem-list-no-dependencies.txt
@@ -1,1 +1,1 @@
-puppetserver-ca 2.6.0
+openvoxserver-ca 3.0.0


### PR DESCRIPTION
openvoxserver-ca is our fork of puppetserver-ca. It now pulls in openfact and not facter anymore.