### PR TITLE
(maint) Drop debian-10 from testing matrix

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -91,7 +91,6 @@ jobs:
         os:
           - [almalinux, '8']
           - [almalinux, '9']
-          - [debian, '10']
           - [debian, '11']
           - [debian, '12']
           # No builds of openvox-server in artifacts.voxpupuli.org yet


### PR DESCRIPTION
Debian 10 was eol last year. Packages have now been dropped from the main deb.debian.org mirrors and are now available only from archive.debian.org, so the images no longer work correctly.