### PR TITLE
openvox-server: depend on openvox-agent 8.21.0 or newer

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -7,7 +7,7 @@
 ezbake: {
    pe: {}
    foss: {
-      redhat: { dependencies: ["openvox-agent >= 8.11.0"],
+      redhat: { dependencies: ["openvox-agent >= 8.21.0"],
                 build-dependencies: ["%{open_jdk}"],
                 # Install some gems
                 install: [
@@ -35,7 +35,7 @@ ezbake: {
                ]
              }
 
-      debian: { dependencies: ["openvox-agent (>= 8.11.0)"],
+      debian: { dependencies: ["openvox-agent (>= 8.21.0)"],
                 build-dependencies: ["openjdk-11-jre-headless"],
                 # Install some gems
                 install: [


### PR DESCRIPTION
with the switch from openvoxserver-cli (a gem) to version 3, it switches from facter as dependency to openfact. openvox-agent is also the first agent build that switches from the facter gem to our openfact gem.

We cannot mix facter and openfact.