### PR TITLE
(ci) Use shared_actions/.github/workflows/beaker_acceptance.yml

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,8 +1,9 @@
 ---
 name: Beaker Acceptance Tests
 run-name: |-
-  Beaker acceptance tests for ${{ inputs.pre-release-build && 'pre-release' || 'release' }} packages of
-  openvox-agent
+  Beaker acceptance tests for openvox-server using
+  ${{ inputs.pre-release-build && 'pre-release' || 'release' }}
+  packages of openvox-agent
   ${{ (inputs.pre-release-build && inputs.openvox-agent-version) ||
       format(' collection: "{0}", version: "{1}" ',
              inputs.collection,
@@ -24,6 +25,19 @@ run-name: |-
 on:
   workflow_dispatch:
     inputs:
+      ref:
+        description: |-
+          (Ref) The git ref of openvox-server to run the Beaker test
+          suite from.
+
+          If testing something from openvox8, this should be a ref off
+          of main.
+
+          If testing something from openvox7, this should be a ref off
+          of the 7.x branch.
+        required: true
+        type: string
+        default: main
       pre-release-build:
         description: |-
           (Pre-release Build) Whether to test unreleased version
@@ -61,9 +75,8 @@ on:
           (Collection) OpenVox collection to use. (ignored if
           Pre-release Build is true)
 
-          NOTE: This should really only be set to openvox8 when
-          testing the main branch. If you need to test openvox7, you
-          should run the pipeline from the 7.x branch instead.
+          If testing something from main, this should be openvox8.
+          If testing something from 7.x, this should be openvox7.
         default: 'openvox8'
         type: string
       artifacts-url:
@@ -76,183 +89,62 @@ on:
 permissions:
   contents: read
 
-env:
-  RUBY_VERSION: '3.3'
-  # Suppress warnings about Bolt gem versus package use.
-  BOLT_GEM: true
-
 jobs:
   acceptance:
-    name: Acceptance Tests
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - [almalinux, '8']
-          - [almalinux, '9']
-          - [debian, '11']
-          - [debian, '12']
-          # No builds of openvox-server in artifacts.voxpupuli.org yet
-          # - [debian, '13', 'amd64', 'daily-latest']
-          - [rocky, '8']
-          - [rocky, '9']
-          - [ubuntu, '18.04']
-          - [ubuntu, '20.04']
-          - [ubuntu, '22.04']
-          - [ubuntu, '24.04']
-    steps:
-      - uses: actions/checkout@v4
-      - id: vm-cluster
-        uses: jpartlow/nested_vms@v1
-        with:
-          os: ${{ matrix.os[0] }}
-          os-version: ${{ matrix.os[1] }}
-          os-arch: ${{ matrix.os[2] || 'x86_64' }}
-          image_version: ${{ matrix.os[3] }}
-          host-root-access: true
-          ruby-version: ${{ env.RUBY_VERSION }}
-          install-openvox: false
-          # Note: the cpu_mode is set to host-model for the sake of
-          # el-9 which expects at least x86_64-2 arch. This depends on
-          # the runner's architecture being sufficient, and there is
-          # probably a better way to get this set on the libvirt
-          # domain instead.
-          vms: |-
-            [
-              {
-                "role": "primary",
-                "count": 1,
-                "cpus": 4,
-                "mem_mb": 8192,
-                "cpu_mode": "host-model"
-              },
-              {
-                "role": "agent",
-                "count": 1,
-                "cpus": 2,
-                "mem_mb": 2048,
-                "cpu_mode": "host-model"
-              }
-            ]
-      - name: Write Install OpenVox Params
-        working-directory: kvm_automation_tooling
-        env:
-          OPENVOX_ARTIFACTS_URL: |-
-            ${{ github.event.inputs.artifacts-url }}
-          OPENVOX_RELEASED: |-
-            ${{ github.event.inputs.pre-release-build == 'false' }}
-          OPENVOX_AGENT_VERSION: |-
-            ${{ ((github.event.inputs.openvox-agent-version == '') && 'latest') ||
-                 github.event.inputs.openvox-agent-version }}
-          OPENVOX_SERVER_VERSION: |-
-            ${{ ((github.event.inputs.openvox-server-version == '') && 'latest') ||
-                 github.event.inputs.openvox-server-version }}
-          OPENVOX_DB_VERSION: |-
-            ${{ ((github.event.inputs.openvoxdb-version == '') && 'latest') ||
-                 github.event.inputs.openvoxdb-version }}
-          OPENVOX_COLLECTION: ${{ github.event.inputs.collection }}
-        run: |-
-          cat > install_openvox_params.json <<EOF
+    uses: 'openvoxproject/shared-actions/.github/workflows/beaker_acceptance.yml@main'
+    with:
+      ref: ${{ inputs.ref }}
+      project-name: openvox-server
+      install-openvox: true
+      openvox-collection: ${{ inputs.collection }}
+      openvox-agent-version: ${{ inputs.openvox-agent-version }}
+      openvox-agent-pre-release-build: ${{ inputs.pre-release-build }}
+      install-openvox-server: true
+      openvox-server-version: ${{ inputs.openvox-server-version }}
+      openvox-server-pre-release-build: ${{ inputs.pre-release-build }}
+      install-openvoxdb: true
+      openvoxdb-version: ${{ inputs.openvoxdb-version }}
+      openvoxdb-pre-release-build: ${{ inputs.pre-release-build }}
+      artifacts-url: ${{ inputs.artifacts-url }}
+      acceptance-working-dir: './'
+      acceptance-pre-suite: |-
+        [
+          "acceptance/suites/pre_suite/openvox/configure_type_defaults.rb",
+          "acceptance/suites/pre_suite/foss/00_setup_environment.rb",
+          "acceptance/suites/pre_suite/foss/070_InstallCACerts.rb",
+          "acceptance/suites/pre_suite/foss/10_update_ca_certs.rb",
+          "acceptance/suites/pre_suite/foss/15_prep_locales.rb",
+          "acceptance/suites/pre_suite/foss/71_smoke_test_puppetserver.rb",
+          "acceptance/suites/pre_suite/foss/80_configure_puppet.rb",
+          "acceptance/suites/pre_suite/foss/85_configure_sut.rb",
+          "acceptance/suites/pre_suite/foss/90_validate_sign_cert.rb",
+          "acceptance/suites/pre_suite/foss/95_install_pdb.rb",
+          "acceptance/suites/pre_suite/foss/99_collect_data.rb"
+        ]
+      acceptance-tests: |-
+        [
+          "acceptance/suites/tests"
+        ]
+      beaker-options: |-
+        {
+          "helper":       "acceptance/lib/helper.rb",
+          "load_path":    "acceptance/lib",
+          "options_file": "acceptance/config/beaker/options.rb"
+        }
+      vms: |-
+        [
           {
-            "openvox_agent_targets": "all",
-            "openvox_server_targets": "primary",
-            "openvox_db_targets": "primary",
-            "openvox_agent_params": {
-              "openvox_collection": "${OPENVOX_COLLECTION}",
-              "openvox_version": "${OPENVOX_AGENT_VERSION}",
-              "openvox_released": ${OPENVOX_RELEASED},
-              "openvox_artifacts_url": "${OPENVOX_ARTIFACTS_URL}"
-            },
-            "openvox_server_params": {
-              "openvox_collection": "${OPENVOX_COLLECTION}",
-              "openvox_version": "${OPENVOX_SERVER_VERSION}",
-              "openvox_released": ${OPENVOX_RELEASED},
-              "openvox_artifacts_url": "${OPENVOX_ARTIFACTS_URL}"
-            },
-            "openvox_db_params": {
-              "openvox_collection": "${OPENVOX_COLLECTION}",
-              "openvox_version": "${OPENVOX_DB_VERSION}",
-              "openvox_released": ${OPENVOX_RELEASED},
-              "openvox_artifacts_url": "${OPENVOX_ARTIFACTS_URL}"
-            },
-            "install_defaults": {
-              "openvox_version": "latest",
-              "openvox_collection": "${OPENVOX_COLLECTION}",
-              "openvox_released": true
-            }
+            "role": "primary",
+            "count": 1,
+            "cpus": 4,
+            "mem_mb": 8192,
+            "cpu_mode": "host-model"
+          },
+          {
+            "role": "agent",
+            "count": 1,
+            "cpus": 2,
+            "mem_mb": 2048,
+            "cpu_mode": "host-model"
           }
-          EOF
-          cat install_openvox_params.json
-      - name: Install OpenVox Components
-        working-directory: kvm_automation_tooling
-        env:
-          # Generated by the nested_vms action.
-          INVENTORY: terraform/instances/inventory.test.yaml
-        run: |-
-          bundle exec bolt plan run \
-            kvm_automation_tooling::install_openvox \
-            --inventory "${INVENTORY}" \
-            --params @install_openvox_params.json
-      - name: Construct hosts.yaml
-        working-directory: kvm_automation_tooling
-        env:
-          HOSTS_YAML: ${{ github.workspace }}/acceptance/hosts.yaml
-          # Generated by the nested_vms action.
-          INVENTORY: terraform/instances/inventory.test.yaml
-        run: |-
-          bundle exec bolt plan run \
-            kvm_automation_tooling::dev::generate_beaker_hosts_file \
-            --inventory "${INVENTORY}" \
-            hosts_yaml="${HOSTS_YAML}"
-          cat "${HOSTS_YAML}"
-      - name: Install Ruby and Run Bundler for Acceptance Tests
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-          bundler-cache: true
-      - name: Write .beaker.yml
-        env:
-          # Generated by the nested_vms action.
-          SSH_KEY: ~/.ssh/ssh-id-test
-        run: |-
-          cat > .beaker.yml <<EOF
-          ---
-          ssh:
-            keys:
-              - ${SSH_KEY}
-          xml:                         true
-          timesync:                    false
-          repo_proxy:                  true
-          add_el_extras:               false
-          'master-start-curl-retries': 30
-          log_level:                   debug
-          preserve_hosts:              always
-          helper:                      acceptance/lib/helper.rb
-          load_path:                   acceptance/lib
-          tests:                       acceptance/suites/tests
-          type:                        aio
-          options_file:                acceptance/config/beaker/options.rb
-          pre_suite:
-            - acceptance/suites/pre_suite/openvox/configure_type_defaults.rb
-            - acceptance/suites/pre_suite/foss/00_setup_environment.rb
-            - acceptance/suites/pre_suite/foss/070_InstallCACerts.rb
-            - acceptance/suites/pre_suite/foss/10_update_ca_certs.rb
-            - acceptance/suites/pre_suite/foss/15_prep_locales.rb
-            - acceptance/suites/pre_suite/foss/71_smoke_test_puppetserver.rb
-            - acceptance/suites/pre_suite/foss/80_configure_puppet.rb
-            - acceptance/suites/pre_suite/foss/85_configure_sut.rb
-            - acceptance/suites/pre_suite/foss/90_validate_sign_cert.rb
-            - acceptance/suites/pre_suite/foss/95_install_pdb.rb
-            - acceptance/suites/pre_suite/foss/99_collect_data.rb
-          EOF
-          cat .beaker.yml
-      - name: Run Beaker
-        run: |-
-          # Options feed in from .beaker.yml generated above
-          bundle exec beaker init --hosts acceptance/hosts.yaml
-          # The provision step is still needed here, see notes in the
-          # kvm_automation_tooling/templates/beaker-hosts.yaml.epp
-          # template...
-          bundle exec beaker provision
-          bundle exec beaker exec
+        ]


### PR DESCRIPTION
Replaces the acceptance.yml's jobs with a call to the reusable beaker_acceptance.yml workflow from the openvoxproject/shared_actions repository.

This version also takes a ref input and should be able to test 7.x suite/packages as well without switching to the 7.x branch.