### PR TITLE
Run tests on JRE11, 17 & 21 (21 without FIPS)

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   clojure-tests:
-    name: Clojure Tests - Java ${{ matrix.version }}
+    name: Clojure Tests - Java ${{ matrix.version }} ${{ matrix.filter }} ${{ matrix.javaargs }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -19,6 +19,13 @@ jobs:
         javaargs: ['with-profile fips', '']
         filter: [':singlethreaded', ':multithreaded']
         version: ['11', '17', '21']
+        exclude:
+          - javaargs: 'with-profile fips'
+            version: '21'
+            filter: ':multithreaded'
+          - javaargs: 'with-profile fips'
+            version: '21'
+            filter: ':singlethreaded'
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo

--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         javaargs: ['with-profile fips', '']
         filter: [':singlethreaded', ':multithreaded']
-        version: ['11', '17']
+        version: ['11', '17', '21']
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['11', '17']
+        java: ['11', '17', '21']
         ruby: ['3.1', '3.2', '3.3', '3.4']
     steps:
       - name: checkout repo

--- a/project.clj
+++ b/project.clj
@@ -137,7 +137,7 @@
                                             (throw unsupported-ex))
                                         11 ["-Djava.security.properties==./dev-resources/java.security.jdk11on-fips"]
                                         17 ["-Djava.security.properties==./dev-resources/java.security.jdk11on-fips"]
-                                        (throw unsupported-ex)))}
+                                        (do)))}
              :fips [:defaults :fips-deps]
 
              :testutils {:source-paths ["test/unit" "test/integration"]}


### PR DESCRIPTION
FIPS support isn't working on Java 21. But that's probably something only PE people used. Be default FIPS mode isn't used. If someone is interested, we can investigate it later.