### PR TITLE
CI: Cleanup build action

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -85,25 +85,18 @@ jobs:
   build:
     name: build openvox-server
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        version: ['11', '17']
     steps:
       - name: checkout repo
         uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: setup java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.version }}
       - name: setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
           bundler-cache: true
+      # uses the Dockerfile to build openvox-server in a container
+      # the container hardcodes the java version
       - name: build it
         run: bundle exec rake vox:build
 

--- a/project.clj
+++ b/project.clj
@@ -168,7 +168,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [com.puppetlabs/trapperkeeper-webserver-jetty10]
                                                [puppetlabs/trapperkeeper-metrics]]
-                      :plugins [[puppetlabs/lein-ezbake "2.6.3-SNAPSHOT-openvox"]]
+                      :plugins [[puppetlabs/lein-ezbake "3.0.1-SNAPSHOT"]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
                                       [com.puppetlabs/trapperkeeper-webserver-jetty10]]


### PR DESCRIPTION
To build openvox-server, we start a container. The Dockerfile hardcodes the Java version. It doesn't make sense to have multiple build jobs in CI.