### PR TITLE
project.clj: Cleanup perforce leftovers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -75,8 +75,10 @@
   :test-paths ["test/unit" "test/integration"]
   :resource-paths ["resources" "src/ruby"]
 
-  :repositories [["releases" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-releases__local/"]
-                 ["snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-snapshots__local/"]]
+  :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
+                                     :username :env/CLOJARS_USERNAME
+                                     :password :env/CLOJARS_PASSWORD
+                                     :sign-releases false}]]
 
   :plugins [[lein-parent "0.3.7"]
             [jonase/eastwood "1.4.2" :exclusions [org.clojure/clojure]]


### PR DESCRIPTION
We run the same configuration as in https://github.com/OpenVoxProject/clj-parent/blob/main/project.clj

* We don't set an explicit repository to fetch dependencies
* we configure clojars.org as a target for *our* future releases