### PR TITLE
ezbake: Introduce service-port variable

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -88,6 +88,7 @@
 
   :uberjar-name "puppet-server-release.jar"
   :lein-ezbake {:vars {:user "puppet"
+                       :service-port 8140
                        :group "puppet"
                        :numeric-uid-gid 52
                        :build-type "foss"


### PR DESCRIPTION
This enables ezbake to use the port in templates, e.g. rendering the systemd unit file. This is required to add a post start command to check if the tcp port is already reachable.