### PR TITLE
Update net-imap

### DIFF
--- a/resources/ext/build-scripts/jruby-stdlib-gem-list.txt
+++ b/resources/ext/build-scripts/jruby-stdlib-gem-list.txt
@@ -1,7 +1,7 @@
 matrix 0.4.2
 minitest 5.15.0
 net-ftp 0.1.3
-net-imap 0.2.3
+net-imap 0.2.5
 net-pop 0.1.1
 net-smtp 0.3.1
 power_assert 2.0.1


### PR DESCRIPTION
Updates net-imap to the latest 0.2.x semver to mitigate [CVE-2025-43857](https://nvd.nist.gov/vuln/detail/cve-2025-43857).

Fix backported in https://github.com/ruby/net-imap/pull/442