### PR TITLE
Allow override of ezbake version and fix ezbake ref passthrough

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ on:
           Branch/tag from ezbake that will be used for openvoxdb/server builds.
         type: string
         default: 'main'
+      ezbake-ver:
+        description: 'The version specified in project.clj in the given ezbake-ref. Will default to the version found in project.clj in this repo if not specified.'
+        type: string
+        required: false
 
 permissions:
   contents: read
@@ -31,4 +35,6 @@ jobs:
       ref: ${{ inputs.ref }}
       deb_platform_list: ${{ inputs.deb_platform_list }}
       rpm_platform_list: ${{ inputs.rpm_platform_list }}
+      ezbake-ref: ${{ inputs.ezbake-ref }}
+      ezbake-ver: ${{ inputs.ezbake-ver }}
     secrets: inherit

--- a/project.clj
+++ b/project.clj
@@ -171,7 +171,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [com.puppetlabs/trapperkeeper-webserver-jetty10]
                                                [puppetlabs/trapperkeeper-metrics]]
-                      :plugins [[puppetlabs/lein-ezbake "3.0.1-SNAPSHOT"]]
+                      :plugins [[puppetlabs/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "3.0.1-SNAPSHOT")]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
                                       [com.puppetlabs/trapperkeeper-webserver-jetty10]]

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -76,8 +76,9 @@ namespace :vox do
       run("cd /ezbake && lein install")
 
       puts "Building openvox-server"
+      ezbake_version_var = ENV['EZBAKE_VERSION'] ? "EZBAKE_VERSION=#{ENV['EZBAKE_VERSION']}" : ''
       run("cd /code && rm -rf ruby && rm -rf output && bundle install --without test && lein install")
-      run("cd /code && COW=\"#{@debs}\" MOCK=\"#{@rpms}\" GEM_SOURCE='https://rubygems.org' EZBAKE_ALLOW_UNREPRODUCIBLE_BUILDS=true EZBAKE_NODEPLOY=true LEIN_PROFILES=ezbake lein with-profile user,ezbake,provided,internal ezbake local-build")
+      run("cd /code && COW=\"#{@debs}\" MOCK=\"#{@rpms}\" GEM_SOURCE='https://rubygems.org' #{ezbake_version_var} EZBAKE_ALLOW_UNREPRODUCIBLE_BUILDS=true EZBAKE_NODEPLOY=true LEIN_PROFILES=ezbake lein with-profile user,ezbake,provided,internal ezbake local-build")
       run_command("sudo chown -R $USER output", print_command: true)
       Dir.glob('output/**/*i386*').each { |f| FileUtils.rm_rf(f) }
       Dir.glob('output/puppetserver-*.tar.gz').each { |f| FileUtils.mv(f, f.sub('puppetserver','openvox-server'))}


### PR DESCRIPTION
Because we want to build 8.11 with an old version of ezbake, and to ease local test/building in the future, this allows the ezbake version to be overridden via the EZBAKE_VERSION env var.

This also passes through ezbake-ref to the shared workflow.