### PR TITLE
Update release condition in workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     # Optional but recommended to use a specific environment
     environment: release
     # Prevent releases from forked repositories
-    if: github.repository_owner == 'OpenVoxProject'
+    if: github.repository_owner == 'OpenVoxProject' && !startsWith(github.ref_name, '99.')
 
     permissions:
       contents: write


### PR DESCRIPTION
This allows us to test things with a tag starting with `99.` and not trigger an actual release.