### PR TITLE
drop gettext from jruby gems

### DIFF
--- a/resources/ext/build-scripts/jruby-gem-list.txt
+++ b/resources/ext/build-scripts/jruby-gem-list.txt
@@ -2,7 +2,6 @@ semantic_puppet 1.1.0
 hocon 1.4.0
 text 1.3.1
 locale 2.1.4
-gettext 3.4.9
 fast_gettext 2.4.0
 concurrent-ruby 1.2.3
 deep_merge 1.2.2

--- a/resources/ext/build-scripts/jruby-gem-list.txt
+++ b/resources/ext/build-scripts/jruby-gem-list.txt
@@ -2,7 +2,6 @@ semantic_puppet 1.1.1
 hocon 1.4.0
 text 1.3.1
 locale 2.1.5
-gettext 3.5.2
 fast_gettext 2.4.0
 concurrent-ruby 1.3.7
 deep_merge 1.2.2


### PR DESCRIPTION
this gem was likely added to support the (brief) module localization effort, in addition to fast_gettext, but it's probably unused by now

see also https://github.com/puppetlabs/r10k/issues/1407