### PR TITLE
Remove testing Java 11 on el8

### DIFF
--- a/acceptance/suites/pre_suite/foss/85_configure_sut.rb
+++ b/acceptance/suites/pre_suite/foss/85_configure_sut.rb
@@ -1,7 +1,0 @@
-step "Use Java 11 on RHEL 8" do
-  if master['platform'].start_with?('el-8')
-    on master, 'yum install -y java-11'
-    on master, 'alternatives --set java java-11-openjdk.x86_64'
-    on master, 'systemctl restart puppetserver'
-  end
-end


### PR DESCRIPTION
This was previously added to test a different Java version than the default. We no longer support Java 11.