### PR TITLE
remove stale dependencies and imports

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,6 @@
 
                  [slingshot]
                  [org.yaml/snakeyaml]
-                 [commons-lang]
                  [commons-io]
 
                  [clj-time]

--- a/src/java/com/puppetlabs/puppetserver/MetricsPuppetProfiler.java
+++ b/src/java/com/puppetlabs/puppetserver/MetricsPuppetProfiler.java
@@ -2,7 +2,6 @@ package com.puppetlabs.puppetserver;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -13,8 +12,6 @@ import java.util.Set;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class MetricsPuppetProfiler implements PuppetProfiler {
 


### PR DESCRIPTION
- remove stale import which got left behind after removal of `StringUtils.join()` method in commit 31e55ab