### PR TITLE
CI: upload artifacts and comment on PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!--
+Thank you for contributing to this project!
+
+- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
+- Please check that here is no existing issue or PR that addresses your problem.
+- Our vulnerabilities reporting process is at https://voxpupuli.org/security/
+
+- The CI will build rpm and deb packages for openvox-server. The packages will be
+stored in a zip archive and uploaded as GitHub artifacts.
+In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
+always named openvox-server-$(git describe). The artifacts are available for 24
+hours.
+
+-->
+
+#### Pull Request (PR) description
+<!--
+Replace this comment with a description of your pull request.
+-->
+
+#### This Pull Request (PR) fixes the following issues
+<!--
+Replace this comment with the list of issues or n/a.
+Use format:
+Fixes #123
+Fixes #124
+-->

--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -85,11 +85,14 @@ jobs:
   build:
     name: build openvox-server
     runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
     steps:
       - name: checkout repo
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          fetch-depth: 0 # So we fetch all history and tags and can build non-tagged versions
       - name: setup ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -99,6 +102,29 @@ jobs:
       # the container hardcodes the java version
       - name: build it
         run: bundle exec rake vox:build
+      - name: get version
+        id: version
+        run: |
+          DESCRIBE=$(git describe --abbrev=9)
+          echo "describe=${DESCRIBE//-/.}" >> $GITHUB_OUTPUT
+      - name: Upload build artifacts
+        id: upload
+        uses: actions/upload-artifact@v6
+        with:
+          name: openvoxdb-${{ steps.version.outputs.describe }}
+          path: output/
+          retention-days: 1 # quite low retention, because the artifacts are quite large
+          overwrite: true # overwrite old artifacts if a PR runs again (artifacts are per PR * per project)
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@v5
+        # Check if the event is not triggered by a fork
+        # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |-
+            The rpm/deb packages and the JAR file for openvox-server are available in a zip archive:
+            ${{ steps.upload.outputs.artifact-url }}
 
   clojure-linting:
     name: Clojure Linting


### PR DESCRIPTION
We did the same for openvoxdb. In each PR, we build the rpm/deb packages. They will be zipped and uploaded as artifacts. Those can be pulled down by users to test their changes. If possible, we also add a comment to the PR with the direct link.