### PR TITLE
Change how we define the version

### DIFF
--- a/scripts/sync_ezbake_dep.rb
+++ b/scripts/sync_ezbake_dep.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+file = ARGV[0] || "project.clj"
+text = File.read(file)
+
+v = text[/^\(defproject\s+\S+\s+"([^"]+)"/m, 1]
+abort("Couldn't find defproject version string in #{file}") unless v
+
+re = /\[org\.openvoxproject\/puppetserver\s+"[^"]+"\]/
+abort("Couldn't find literal [org.openvoxproject/puppetserver \"...\"] in #{file}") unless text.match?(re)
+
+text.sub!(re, %[[org.openvoxproject/puppetserver "#{v}"]])
+File.write(file, text)
+
+puts "Synced ezbake dep to #{v}"


### PR DESCRIPTION
In order to use `lein release` and it's automated method of bumping versions, the version string has to directly be in the defproject declaration. We could write our own version bumping logic, but we'd have to recreate what 'lein change version' does.

Instead, this adds a small script to sync the version defined in ezbake defs to what is in defproject. This allows us to use the same shared release GitHub action as all the other projects, and still keep this line in sync.