### PR TITLE
More changes for FIPS builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,6 @@ acceptance/scripts/hosts.cfg
 # Ignore temp directory where BC jars go during build
 # in case it doesn't get cleaned up.
 resources/ext/build-scripts/bc-fips-jars
+resources/ext/build-scripts/bc-nonfips-jars
 
 .DS_Store
-

--- a/project.clj
+++ b/project.clj
@@ -253,8 +253,19 @@
                                                [org.openvoxproject/trapperkeeper-metrics]]
                       :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.2")]]
                       :name "puppetserver"}
-             :uberjar {:dependencies [[org.bouncycastle/bcpkix-jdk18on]
-                                      [org.openvoxproject/trapperkeeper-webserver-jetty10]]
+
+             :ezbake-fips {:dependencies ^:replace [[org.clojure/clojure]
+                                                    [org.bouncycastle/bcpkix-jdk18on]
+                                                    [org.openvoxproject/jruby-utils]
+                                                    ;; Do not modify this line. It is managed by the release process
+                                                    ;; via the scripts/sync_ezbake_dep.rb script.
+                                                    [org.openvoxproject/puppetserver "8.12.0-SNAPSHOT"]
+                                                    [org.openvoxproject/trapperkeeper-webserver-jetty10]
+                                                    [org.openvoxproject/trapperkeeper-metrics]]
+                            :uberjar-exclusions [#"^org/bouncycastle/.*"]
+                            :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.2")]]
+                      :name "puppetserver"}
+             :uberjar {:dependencies [[org.openvoxproject/trapperkeeper-webserver-jetty10]]
                        :aot [puppetlabs.trapperkeeper.main
                              puppetlabs.trapperkeeper.services.status.status-service
                              puppetlabs.trapperkeeper.services.metrics.metrics-service

--- a/resources/ext/build-scripts/install-vendored-gems.sh
+++ b/resources/ext/build-scripts/install-vendored-gems.sh
@@ -15,7 +15,7 @@ install_gems () {
     gem_list+=("$gem_name:$gem_version")
   done < $gem_file
 
-  java -cp puppet-server-release.jar:jruby-9k.jar clojure.main -m puppetlabs.puppetserver.cli.gem --config jruby.conf -- install ${additional_args:+"$additional_args"} --no-document "${gem_list[@]}"
+  java -cp ext/build-scripts/bc-nonfips-jars/*:puppet-server-release.jar:jruby-9k.jar clojure.main -m puppetlabs.puppetserver.cli.gem --config jruby.conf -- install ${additional_args:+"$additional_args"} --no-document "${gem_list[@]}"
 }
 
 SOURCE="${BASH_SOURCE[0]}"

--- a/scripts/sync_ezbake_dep.rb
+++ b/scripts/sync_ezbake_dep.rb
@@ -10,7 +10,7 @@ abort("Couldn't find defproject version string in #{file}") unless v
 re = /\[org\.openvoxproject\/puppetserver\s+"[^"]+"\]/
 abort("Couldn't find literal [org.openvoxproject/puppetserver \"...\"] in #{file}") unless text.match?(re)
 
-text.sub!(re, %[[org.openvoxproject/puppetserver "#{v}"]])
+text.gsub!(re, %[[org.openvoxproject/puppetserver "#{v}"]])
 File.write(file, text)
 
 puts "Synced ezbake dep to #{v}"


### PR DESCRIPTION
The way we were previous building this, the non-FIPS BC code was included in the uberjar. So when we run the server with the FIPS BC jars on the classpath, it mostly works because we put the FIPS jars first on the classpath, but in some instances you can get errors with trying to load an already loaded sealed class, particularly when running puppetserver cli commands.

This removes the BC code from the uberjar for FIPS builds so that only the FIPS BC jars are loaded. Commands like 'puppetserver gem install' still fail since jruby-openssl doesn't support BC FIPS, but this brings us to parity with Puppet FIPS functionality, and prevents unforseen issues around having both code paths present.