### PR TITLE
split_external_cas test: don't use /tmp

### DIFF
--- a/acceptance/suites/tests/certificate_authority/split_external_cas.rb
+++ b/acceptance/suites/tests/certificate_authority/split_external_cas.rb
@@ -16,8 +16,10 @@ tag 'audit:medium',
 
 step "Copy certificates and configuration files to the master..."
 fixture_dir = File.expand_path('../fixtures', __FILE__)
-testdir = master.tmpdir('jetty_external_root_ca')
-backupdir = master.tmpdir('jetty_external_root_ca_backup')
+testdir = "/var/here-be-dragons"
+backupdir = "/var/here-be-backup-dragons"
+on master, "mkdir -p #{testdir}"
+on master, "mkdir -p #{backupdir}"
 fixtures = PuppetX::Acceptance::ExternalCertFixtures.new(fixture_dir, testdir)
 
 jetty_confdir = master['puppetserver-confdir']
@@ -37,6 +39,8 @@ teardown do
   on master, "\\cp -frp #{backupdir}/puppetserver/* #{jetty_confdir}/../"
   on(master, puppet_resource('service', master['puppetservice'], 'ensure=stopped'))
   on(master, puppet_resource('service', master['puppetservice'], 'ensure=running'))
+  on master, "rm -rf #{testdir}"
+  on master, "rm -rf #{backupdir}"
 end
 
 # Backup files in scope for modification by test


### PR DESCRIPTION
Since we added PrivateTmp=true in the service file in https://github.com/OpenVoxProject/ezbake/commit/900b4eee0dfda861fd99934ce5f1532c411ab373, when Beaker moves files into a directory in /tmp, openvox-server will not be able to read them because systemd provides the service with a clean /tmp from a tmpfs.

Furthermore, Beaker doesn't have a nice way of using mktemp specifying a directory outside of /tmp, and messing the the TMPDIR env var and all the places Beaker tries to manipulate host env vars is a path towards pain.

This puts the files in a /var directory instead and cleans it up afterwards.