### PR TITLE
client_may_use_external_cert_chains test: don't use /tmp

### DIFF
--- a/acceptance/suites/tests/https/client_may_use_external_cert_chains.rb
+++ b/acceptance/suites/tests/https/client_may_use_external_cert_chains.rb
@@ -3,7 +3,8 @@ test_name "Ensure Puppet Server's HTTP client may use external cert chains" do
   ## This test currently fails on FIPS (see PE-34102). Remove this once that is resolved.
   skip_test if master.fips_mode?
 
-  reports_tmpdir = master.tmpdir('external-reports')
+  reports_tmpdir = "/var/reporting-live-from-beaker-im-ron-burgundy"
+  on master, "mkdir -p #{reports_tmpdir}"
   server_key = reports_tmpdir + '/server.key'
   server_cert = reports_tmpdir + '/server.crt'
   server_rb = reports_tmpdir + '/server.rb'
@@ -58,6 +59,7 @@ EOF
 
   teardown do
     on master, kill_server
+    on master, "rm -rf #{reports_tmpdir}"
   end
 
 


### PR DESCRIPTION
Since we added PrivateTmp=true in the service file in OpenVoxProject/ezbake@900b4ee, when Beaker moves files into a directory in /tmp, openvox-server will not be able to read them because systemd provides the service with a clean /tmp from a tmpfs.

Furthermore, Beaker doesn't have a nice way of using mktemp specifying a directory outside of /tmp, and messing the the TMPDIR env var and all the places Beaker tries to manipulate host env vars is a path towards pain.

This puts the files in a /var directory instead and cleans it up afterwards.

The other use of master.tmpdir should be okay because only the puppetserver CLI is executed against the file in there, and that won't be subject to the systemd PrivateTmp changes.