### PR TITLE
CI: Drop beaker-abs & beaker-vmpooler, allow latest beaker-hostgenerator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,7 @@ gem 'rake', :group => [:development, :test]
 group :test do
   gem 'rspec'
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 6.0')
-  gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 2.4")
-  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 1.0")
-  gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1.3")
+  gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "< 4")
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || "~> 4.0")
   gem 'uuidtools'
   gem 'httparty'


### PR DESCRIPTION
those gems are only used for the acceptance testing