### PR TITLE
CI: Update comment with ZIP link

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -115,14 +115,25 @@ jobs:
           path: output/
           retention-days: 1 # quite low retention, because the artifacts are quite large
           overwrite: true # overwrite old artifacts if a PR runs again (artifacts are per PR * per project)
-      - name: Add comment
-        uses: peter-evans/create-or-update-comment@v5
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v3
         # Check if the event is not triggered by a fork
         # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks
         if: github.event.pull_request.head.repo.full_name == github.repository
+        id: find-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- build-artifacts -->'
+      - name: Add or update comment
+        uses: peter-evans/create-or-update-comment@v5
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
           body: |-
+            <!-- build-artifacts -->
             The rpm/deb packages and the JAR file for openvox-server are available in a zip archive:
             ${{ steps.upload.outputs.artifact-url }}
 


### PR DESCRIPTION
Previously we added a new comment everytime we created a new zip file. Now we check for existing comment from the bot and just update it. Initially added by Nick in openvoxdb:

* https://github.com/OpenVoxProject/openvoxdb/pull/169

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
