### PR TITLE
Downgrade ring-core to version 1.14.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -106,7 +106,12 @@
                          [prismatic/schema "1.4.1"]
                          [ring-basic-authentication "1.2.0"]
                          [ring/ring-codec "1.3.0"]
-                         [ring/ring-core "1.15.3"]
+                         ;; DO NOT UPGRADE PAST 1.14+! In 1.15.x, Content-Length is added to the
+                         ;; response headers automatically rather than transferring it chunked,
+                         ;; and also string flushing behavior is changed, and some part of the system
+                         ;; does not handle one or both of these correctly. We need to debug this and
+                         ;; fix it before upgrading.
+                         [ring/ring-core "1.14.2"]
                          [ring/ring-mock "0.6.2"]
                          [slingshot "0.12.2"]]
 


### PR DESCRIPTION
Downgrade ring-core to 1.14.2 due to issues with 1.15.x. In 1.15.x, the Content-Length header is added to responses automatically, rather than using `Transfer-Encoding: chunked`, which might cause problems when we also gzip the response. Also, changes to how string flushing is performed was changed, with flushing being performed less often. It seems some part of the system doesn't like one or both of these things, so we need to do some deeper debugging before upgrading to 1.15.x.

Using this in favor of https://github.com/OpenVoxProject/openvox-server/pull/182. Thank you for putting that PR up to get a quick revert @corporate-gadfly !