### PR TITLE
Change chown during install to check java.security.fips file existence

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -30,7 +30,7 @@ ezbake: {
                  "install --directory /etc/puppetlabs/puppet/ssl",
                  "chown -R puppet:puppet /etc/puppetlabs/puppet/ssl",
                  "find /etc/puppetlabs/puppet/ssl -type d -print0 | xargs -0 chmod 770",
-                 "chown puppet:puppet /opt/puppetlabs/server/data/puppetserver/java.security.fips"
+                 "if [ -f /opt/puppetlabs/server/data/puppetserver/java.security.fips ];then chown puppet:puppet /opt/puppetlabs/server/data/puppetserver/java.security.fips;fi"
                ]
              }
 


### PR DESCRIPTION
On non-FIPS, the file doesn't exist and emits a warning on install.