### PR TITLE
Correct the name of generated artifact archives

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -111,7 +111,7 @@ jobs:
         id: upload
         uses: actions/upload-artifact@v6
         with:
-          name: openvoxdb-${{ steps.version.outputs.describe }}
+          name: openvox-server-${{ steps.version.outputs.describe }}.zip
           path: output/
           retention-days: 1 # quite low retention, because the artifacts are quite large
           overwrite: true # overwrite old artifacts if a PR runs again (artifacts are per PR * per project)


### PR DESCRIPTION
#### Pull Request (PR) description

The per-PR artifact archive is currently called for example `openvoxdb-8.12.1.11.g2854baaa2`. The prefix is incorrect and is lacking a `.zip` suffix even though it's a Zip archive. This PR fixes that.

#### This Pull Request (PR) fixes the following issues
n/a