### PR TITLE
Add Podman compatibility to vox:build task

### DIFF
--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -54,7 +54,7 @@ def image_exists
 end
 
 def container_exists
-  !`docker container ls --all --filter 'name=#{@container}' --format json`.strip.empty?
+  !`docker container ls --all --filter 'name=#{@container}' --format '{{json .ID}}'`.strip.empty?
 end
 
 def teardown


### PR DESCRIPTION
Prior to this commit, running the `vox:build` task via the `podman-docker` shim would fail as `podman ls --format json` prints an empty array, `[]`, when no containers match `--filter`. This differs from `docker ls` behavior of printing nothing to STDOUT. This extra output resulted in the `container_exists` function returning a false positive, which caused the task to fail when trying to run `podman stop` on containers that didn't exist.

This commit changes the command to use `--format='{{json .ID}}'` as this produces the same behavior from both `podman` and `docker`: no STDOUT when nothing matches, and a quoted string containing the container ID when there is a match.
