### PR TITLE
Remove dujour-version-check from dependencies

### DIFF
--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -40,7 +40,6 @@ DEP_BUILD_ORDER = [
   'ring-middleware',
   'jruby-utils',
   'clj-shell-utils',
-  'dujour-version-check',
   'clj-rbac-client',
   'trapperkeeper-authorization',
   'trapperkeeper-metrics',


### PR DESCRIPTION
Remove `dujour-version-check` from the dependencies list. Follow on to #231 .