### PR TITLE
replace Joda-Time with with java.time API

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -73,7 +73,6 @@
                          [ch.qos.logback/logback-core ~logback-version]
                          [cheshire "5.13.0"]
                          [clj-commons/fs "1.6.312"]
-                         [clj-time "0.15.2"]
                          [com.fasterxml.jackson.core/jackson-core ~jackson-version]
                          [com.fasterxml.jackson.core/jackson-databind ~jackson-version]
                          [com.fasterxml.jackson.module/jackson-module-afterburner ~jackson-version]
@@ -129,7 +128,6 @@
 
   :dependencies [[org.clojure/clojure]
                  [clj-commons/fs]
-                 [clj-time]
                  [commons-io]
                  [grimradical/clj-semver :exclusions [org.clojure/clojure]]
                  [io.dropwizard.metrics/metrics-core]

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -1,8 +1,5 @@
 (ns puppetlabs.puppetserver.certificate-authority
-  (:require [clj-time.coerce :as time-coerce]
-            [clj-time.core :as time]
-            [clj-time.format :as time-format]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
@@ -23,12 +20,13 @@
            (java.security PrivateKey PublicKey)
            (java.security.cert CRLException CertPathValidatorException X509CRL X509Certificate)
            (java.text SimpleDateFormat)
-           (java.time LocalDateTime ZoneId)
-           (java.util Date)
+           (java.time Instant LocalDateTime ZoneId ZoneOffset ZonedDateTime)
+           (java.time.format DateTimeFormatterBuilder TextStyle)
+           (java.time.temporal ChronoUnit)
+           (java.util Date Locale)
            (java.util.concurrent.locks ReentrantReadWriteLock)
            (org.apache.commons.io IOUtils)
-           (org.bouncycastle.pkcs PKCS10CertificationRequest)
-           (org.joda.time DateTime)))
+           (org.bouncycastle.pkcs PKCS10CertificationRequest)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public utilities
@@ -394,11 +392,11 @@
    and the dates will be based on the current time. Returns a map in the
    form {:not-before Date :not-after Date}."
   [ca-ttl :- schema/Int]
-  (let [now        (time/now)
-        not-before (time/minus now (time/days 1))
-        not-after  (time/plus now (time/seconds ca-ttl))]
-    {:not-before (.toDate not-before)
-     :not-after  (.toDate not-after)}))
+  (let [now        (ZonedDateTime/now ZoneOffset/UTC)
+        not-before (.minus now 1 ChronoUnit/DAYS)
+        not-after  (.plus now ca-ttl ChronoUnit/SECONDS)]
+    {:not-before (Date/from (.toInstant not-before))
+     :not-after  (Date/from (.toInstant not-after))}))
 
 
 (schema/defn settings->cadir-paths
@@ -660,20 +658,25 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Inventory File
 
+(def utc-zone (ZoneId/of "UTC"))
+
 (def inventory-date-formatter
-  (time-format/formatter "YYY-MM-dd'T'HH:mm:ssz"))
+  (-> (DateTimeFormatterBuilder.)
+      (.appendPattern "uuuu-MM-dd'T'HH:mm:ss")
+      (.appendGenericZoneText TextStyle/SHORT)
+      (.toFormatter Locale/US)
+      (.withZone utc-zone)))
 
 (schema/defn format-date-time :- schema/Str
   "Formats a date-time into the format expected by the ruby puppet code."
   [date-time :- Date]
-  (time-format/unparse
-    inventory-date-formatter
-    (time-coerce/from-date date-time)))
+  (.format inventory-date-formatter
+           (ZonedDateTime/ofInstant (.toInstant date-time) ZoneOffset/UTC)))
 
-(schema/defn parse-date-time :- DateTime
-  "parses a date-time string into a DateTime instance"
+(schema/defn parse-date-time :- ZonedDateTime
+  "parses a date-time string into a ZonedDateTime instance"
   [date-time :- schema/Str]
-  (time-format/parse inventory-date-formatter date-time))
+  (ZonedDateTime/parse date-time inventory-date-formatter))
 
 (def buffer-copy-size (* 64 1024))
 
@@ -804,18 +807,18 @@
     false))
 
 (schema/defn is-not-expired? :- schema/Bool
-  [now :- DateTime
+  [now :- ZonedDateTime
    [_serial _not-before not-after _row-subject] :- [schema/Str]]
   (if-let [not-after-date (parse-date-time not-after)]
-    (time/before? now not-after-date)
+    (.isBefore now not-after-date)
     ;; lack of an end date means we can't tell if it is expired or not, so assume it isn't.
     false))
 
 (schema/defn is-expired? :- schema/Bool
-  [now :- DateTime
+  [now :- ZonedDateTime
    [_serial _not-before not-after _row-subject] :- [schema/Str]]
   (if-let [not-after-date (parse-date-time not-after)]
-    (time/after? now not-after-date)
+    (.isAfter now not-after-date)
     ;; lack of an end date means we can't tell if it is expired or not, so assume it isn't.
     false))
 
@@ -848,7 +851,7 @@
     (log/trace (i18n/trs "Extracting expired serials from inventory file {0}" cert-inventory))
     (if (fs/exists? cert-inventory)
       (with-open [inventory-reader (io/reader cert-inventory)]
-        (let [now (time/now)]
+        (let [now (ZonedDateTime/now ZoneOffset/UTC)]
           (doall
             (->>
               (line-seq inventory-reader)
@@ -870,7 +873,7 @@
       (with-open [inventory-reader (io/reader cert-inventory)]
         (let [inventory-rows (map extract-inventory-row-contents (line-seq inventory-reader))
               cn-subject (utils/cn certname)
-              now (time/now)]
+              now (ZonedDateTime/now ZoneOffset/UTC)]
           (doall
             (->> inventory-rows
                  (filter (partial is-subject-in-inventory-row? cn-subject))
@@ -1823,19 +1826,19 @@
     (slurp cacrl)))
 
 (schema/defn ^:always-validate
-  get-file-last-modified :- DateTime
-  "Given a path to a file, return a Joda DateTime instance of when the file was last modified.
+  get-file-last-modified :- ZonedDateTime
+  "Given a path to a file, return a ZonedDateTime instance of when the file was last modified.
    an optional lock, description, and timeout may be passed to serialize access to files."
   ([path :- schema/Str]
    (let [last-modified-milliseconds (.lastModified (io/file path))]
-        (time-coerce/from-long last-modified-milliseconds)))
+        (ZonedDateTime/ofInstant (Instant/ofEpochMilli last-modified-milliseconds) ZoneOffset/UTC)))
   ([path :- schema/Str
     lock :- ReentrantReadWriteLock
     lock-descriptor :- schema/Str
     lock-timeout :- PosInt]
    (common/with-safe-read-lock lock lock-descriptor lock-timeout
      (let [last-modified-milliseconds (.lastModified (io/file path))]
-          (time-coerce/from-long last-modified-milliseconds)))))
+          (ZonedDateTime/ofInstant (Instant/ofEpochMilli last-modified-milliseconds) ZoneOffset/UTC)))))
 
 (schema/defn ^:always-validate reject-delta-crl
   [crl :- CertificateRevocationList]

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -1,8 +1,6 @@
 (ns puppetlabs.services.ca.certificate-authority-core
   (:require [bidi.schema :as bidi-schema]
             [cheshire.core :as cheshire]
-            [clj-time.core :as time]
-            [clj-time.format :as time-format]
             [clojure.java.io :as io]
             [clojure.string :as string]
             [clojure.tools.logging :as log]
@@ -27,7 +25,9 @@
   (:import (clojure.lang IFn)
            (java.io ByteArrayInputStream InputStream StringWriter)
            (java.security.cert X509Certificate)
-           (org.joda.time DateTime)))
+           (java.time ZonedDateTime)
+           (java.time.format DateTimeFormatterBuilder DateTimeParseException TextStyle)
+           (java.util Locale)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Constants
@@ -39,16 +39,30 @@
 ;;; 'handler' functions for HTTP endpoints
 
 
-(schema/defn format-http-date :- (schema/maybe DateTime)
-  "Formats an http-date into joda time.  Returns nil for malformed or nil
-   http-dates"
+(def http-date-formatter
+  ;; RFC 822 / RFC 7231 http-date without the day-of-week field.
+  ;; appendGenericZoneText handles GMT, UTC, and named zones natively.
+  ;; The day-of-week prefix is stripped before parsing (see format-http-date)
+  ;; to avoid day-of-week/date conflicts in java.time's strict resolver.
+  (-> (DateTimeFormatterBuilder.)
+      (.parseCaseInsensitive)
+      (.appendPattern "dd MMM uuuu HH:mm:ss ")
+      (.appendGenericZoneText TextStyle/SHORT)
+      (.toFormatter Locale/US)
+      (.withZone ca/utc-zone)))
+
+(schema/defn format-http-date :- (schema/maybe ZonedDateTime)
+  "Parses an RFC 822 http-date into a ZonedDateTime. Returns nil for malformed
+   or nil http-dates."
   [http-date :- (schema/maybe schema/Str)]
   (when http-date
     (try
-      (time-format/parse
-        (time-format/formatters :rfc822)
-        (string/replace http-date #"GMT" "+0000"))
-      (catch IllegalArgumentException _
+      (ZonedDateTime/parse
+        ;; Strip optional leading day-of-week (e.g. "Wed, ") to avoid
+        ;; day-of-week conflicts for far-future dates in java.time.
+        (string/replace http-date #"^[A-Za-z]+,\s*" "")
+        http-date-formatter)
+      (catch DateTimeParseException _
         nil))))
 
 (defn handle-get-certificate
@@ -58,7 +72,7 @@
               last-modified-date-time (format-http-date last-modified-val)
               cert-last-modified-date-time (ca/get-file-last-modified certificate-path)]
           (if (or (nil? last-modified-date-time)
-                  (time/after? cert-last-modified-date-time last-modified-date-time))
+                  (.isAfter cert-last-modified-date-time last-modified-date-time))
             (rr/response (slurp certificate-path))
             (-> (rr/response nil)
                 (rr/status 304))))
@@ -108,8 +122,8 @@
     ;; window of time between when the last-modified is read and when the crl content is potentially read.
     (common/with-safe-read-lock lock descriptor timeout
         (if (or (nil? agent-crl-last-modified-date-time)
-                (time/after? (ca/get-file-last-modified path lock descriptor timeout)
-                             agent-crl-last-modified-date-time))
+                (.isAfter (ca/get-file-last-modified path lock descriptor timeout)
+                          agent-crl-last-modified-date-time))
           (-> (ca/get-certificate-revocation-list path lock descriptor timeout)
               (rr/response)
               (rr/content-type "text/plain"))

--- a/src/clj/puppetlabs/services/jruby/jruby_metrics_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_metrics_core.clj
@@ -7,14 +7,12 @@
             [puppetlabs.trapperkeeper.services.status.status-core :as status-core]
             [puppetlabs.comidi :as comidi]
             [puppetlabs.i18n.core :refer [trs]]
-            [clj-time.core :as time]
-            [clj-time.format :as time-format]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol])
   (:import (com.codahale.metrics MetricRegistry Gauge Counter Histogram Meter Timer)
            (clojure.lang Atom IFn)
+           (java.time ZoneOffset ZonedDateTime)
+           (java.time.format DateTimeFormatter)
            (java.util.concurrent TimeUnit)
-           (org.joda.time DateTime)
-           (org.joda.time.format DateTimeFormatter)
            (org.slf4j MDC)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -121,19 +119,19 @@
 ;;; Private
 
 (schema/def ^:always-validate datetime-formatter :- DateTimeFormatter
-  "The date/time formatter used to produce timestamps using clj-time.
-  This matches the format used by PuppetDB."
-  (time-format/formatters :date-time))
+  "The date/time formatter used to produce timestamps.
+  This matches the format used by OpenVoxDB."
+  DateTimeFormatter/ISO_OFFSET_DATE_TIME)
 
 (schema/defn ^:always-validate format-date-time :- schema/Str
-  "Given a DateTime object, return a human-readable, formatted string."
-  [date-time :- DateTime]
-  (time-format/unparse datetime-formatter date-time))
+  "Given a ZonedDateTime object, return a human-readable, formatted string."
+  [date-time :- ZonedDateTime]
+  (.format datetime-formatter date-time))
 
 (schema/defn ^:always-validate timestamp :- schema/Str
   "Returns a nicely-formatted string of the current date/time."
   []
-  (format-date-time (time/now)))
+  (format-date-time (ZonedDateTime/now ZoneOffset/UTC)))
 
 (schema/defn timestamped-reason :- TimestampedReason
   [reason :- jruby-schemas/JRubyEventReason]

--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -1,8 +1,6 @@
 (ns puppetlabs.services.certificate-authority.certificate-authority-int-test
   (:require
     [cheshire.core :as json]
-    [clj-time.core :as time]
-    [clj-time.format :as time-format]
     [clojure.java.io :as io]
     [clojure.test :refer [deftest is testing use-fixtures]]
     [me.raynes.fs :as fs]
@@ -25,7 +23,8 @@
     [ring.mock.request :as mock]
     [ring.util.codec :as ring-codec]
     [schema.test :as schema-test])
-  (:import (java.util Date Random)
+  (:import (java.time ZoneOffset ZonedDateTime)
+           (java.util Date Random)
            (java.util.concurrent TimeUnit)
            (javax.net.ssl SSLException)))
 
@@ -1159,11 +1158,10 @@
                       :headers {"Accept" "application/json"}})]
        (is (= 200 (:status response)))
        (let [body (json/parse-string (:body response))
-             ca-exp (get-in body ["ca-certs" "Puppet CA: localhost"])
-             crl-exp (get-in body ["crls" "Puppet CA: localhost"])
-             formatter (time-format/formatter "YYY-MM-dd'T'HH:mm:ssz")]
-         (is (time/after? (time-format/parse formatter ca-exp) (time/now)))
-         (is (time/after? (time-format/parse formatter crl-exp) (time/now))))))))
+              ca-exp (get-in body ["ca-certs" "Puppet CA: localhost"])
+              crl-exp (get-in body ["crls" "Puppet CA: localhost"])]
+          (is (.isAfter (ZonedDateTime/parse ca-exp ca/inventory-date-formatter) (ZonedDateTime/now ZoneOffset/UTC)))
+          (is (.isAfter (ZonedDateTime/parse crl-exp ca/inventory-date-formatter) (ZonedDateTime/now ZoneOffset/UTC))))))))
 
 (deftest update-crl-endpoint-test
   (bootstrap/with-puppetserver-running-with-mock-jrubies

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -1,7 +1,5 @@
 (ns puppetlabs.puppetserver.certificate-authority-test
-  (:require [clj-time.coerce :as time-coerce]
-            [clj-time.core :as time]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
             [clojure.set :as set]
             [clojure.string :as string]
             [clojure.test :refer [deftest is testing use-fixtures]]
@@ -27,11 +25,11 @@
            (java.security MessageDigest PublicKey)
            (java.security.cert X509CRL X509Certificate)
            (java.time LocalDateTime ZoneOffset ZonedDateTime)
+           (java.time.temporal ChronoUnit)
            (java.util Date)
            (java.util.concurrent TimeUnit)
            (java.util.concurrent.locks ReentrantReadWriteLock)
-           (org.bouncycastle.asn1.x509 SubjectPublicKeyInfo)
-           (org.joda.time DateTime Period)))
+           (org.bouncycastle.asn1.x509 SubjectPublicKeyInfo)))
 
 (use-fixtures :once schema-test/validate-schemas)
 (use-fixtures :each #(logutils/with-test-logging (%)))
@@ -53,6 +51,11 @@
 (def autosign-confs-dir (str test-resources-dir "/autosign_confs"))
 (def autosign-exes-dir (str test-resources-dir "/autosign_exes"))
 (def csr-attributes-dir (str test-resources-dir "/csr_attributes"))
+
+(defn within-seconds?
+  "True if actual is within tolerance-seconds of expected."
+  [expected actual tolerance-seconds]
+  (< (Math/abs (.between ChronoUnit/SECONDS expected actual)) tolerance-seconds))
 (def bundle-dir (str test-pems-dir "/bundle"))
 (def bundle-cadir (str bundle-dir "/ca"))
 
@@ -439,22 +442,19 @@
              (ca/get-certificate-request csrdir "test-agent"))))))
 
 (deftest autosign-certificate-request!-test
-  (let [now                (time/epoch)
-        two-years          (* 60 60 24 365 2)
-        settings           (-> (testutils/ca-sandbox! cadir)
-                               (assoc :ca-ttl two-years))
-        csr                (-> (:csrdir settings)
-                               (ca/path-to-cert-request "test-agent")
-                               (utils/pem->csr))
+  (let [two-years-in-seconds  (* 60 60 24 365 2)
+        settings              (-> (testutils/ca-sandbox! cadir)
+                                  (assoc :ca-ttl two-years-in-seconds))
+        csr                   (-> (:csrdir settings)
+                                  (ca/path-to-cert-request "test-agent")
+                                  (utils/pem->csr))
         expected-cert-path (ca/path-to-cert (:signeddir settings) "test-agent")
         old-fn @common/action-registration-function
         call-results (atom [])
-        new-fn (fn [value] (swap! call-results conj value))]
+        new-fn             (fn [value] (swap! call-results conj value))
+        before-sign        (ZonedDateTime/now ZoneOffset/UTC)]
     (reset! common/action-registration-function new-fn)
-    ;; Fix the value of "now" so we can reliably test the dates
-    (time/do-at now
-      (ca/autosign-certificate-request! "test-agent" csr settings (constantly nil)))
-
+    (ca/autosign-certificate-request! "test-agent" csr settings (constantly nil))
     (testing "requests are autosigned and saved to disk"
       (is (fs/exists? expected-cert-path)))
 
@@ -466,20 +466,18 @@
         (testutils/assert-issuer cert "CN=Puppet CA: localhost"))
 
       (testing "certificate has not-before/not-after dates based on $ca-ttl"
-        (let [not-before (time-coerce/from-date (.getNotBefore cert))
-              not-after (time-coerce/from-date (.getNotAfter cert))]
+        (let [not-before (ZonedDateTime/ofInstant (.toInstant (.getNotBefore cert)) ZoneOffset/UTC)
+              not-after  (ZonedDateTime/ofInstant (.toInstant (.getNotAfter cert)) ZoneOffset/UTC)]
           (testing "not-before is 1 day before now"
-            (is (= (time/minus now (time/days 1)) not-before)))
+              (is (within-seconds? (.minus before-sign 1 ChronoUnit/DAYS) not-before 60)))
           (testing "not-after is 2 years from now"
-            (is (= (time/plus now (time/years 2)) not-after)))))
-
+              (is (within-seconds? (.plus before-sign two-years-in-seconds ChronoUnit/SECONDS) not-after 60)))))
       (testing "correctly reports node activity"
         (is (= [{:type :add,
                  :targets ["test-agent"],
                  :meta {:type :certificate}}]
-               @call-results)))
-      (reset! common/action-registration-function old-fn))))
-
+                @call-results))))
+    (reset! common/action-registration-function old-fn)))
 (deftest autosign-without-capub
   (testing "The CA public key file is not necessary to autosign"
     (let [settings  (testutils/ca-sandbox! cadir)
@@ -1347,12 +1345,14 @@
         subject-pub  (utils/get-public-key subject-keys)
         subject      "subject"
         subject-dn   (utils/cn subject)
-        not-after    (-> (DateTime/now)
-                         (.plus (Period/years 5))
-                         (.toDate))
-        not-before   (-> (DateTime/now)
-                         (.plus (Period/years 5))
-                         (.toDate))
+        not-after    (-> (ZonedDateTime/now ZoneOffset/UTC)
+                         (.plus 5 ChronoUnit/YEARS)
+                         (.toInstant)
+                         (Date/from))
+        not-before   (-> (ZonedDateTime/now ZoneOffset/UTC)
+                         (.plus 5 ChronoUnit/YEARS)
+                         (.toInstant)
+                         (Date/from))
         cn           (utils/cn "Root CA")
         cert         (utils/sign-certificate cn (utils/get-private-key issuer-keys)
                                              666 not-before not-after cn issuer-pub
@@ -1852,12 +1852,14 @@
           ca-key-pair  (utils/generate-key-pair 512)
           ca-priv-key  (utils/get-private-key ca-key-pair)
           ca-pub-key   (utils/get-public-key ca-key-pair)
-          not-after    (-> (DateTime/now)
-                           (.plus (Period/years 5))
-                           (.toDate))
-          not-before   (-> (DateTime/now)
-                           (.plus (Period/years 5))
-                           (.toDate))
+          not-after    (-> (ZonedDateTime/now ZoneOffset/UTC)
+                           (.plus 5 ChronoUnit/YEARS)
+                           (.toInstant)
+                           (Date/from))
+          not-before   (-> (ZonedDateTime/now ZoneOffset/UTC)
+                           (.plus 5 ChronoUnit/YEARS)
+                           (.toInstant)
+                           (Date/from))
           cn           (utils/cn "Root CA")
           cert         (utils/sign-certificate cn ca-priv-key
                                                666 not-before not-after cn ca-pub-key
@@ -2177,7 +2179,7 @@
                         public-key
                         (.getThisUpdate crl)
                         ;; create a date 5 days from now using java.time
-                        (-> (ZonedDateTime/now)
+                        (-> (ZonedDateTime/now ZoneOffset/UTC)
                             (.plusDays 5)
                             (.toInstant)
                             (Date/from))


### PR DESCRIPTION
- remove clj-time which was used to bring in Joda Time transitively

See https://github.com/OpenVoxProject/openvoxdb/issues/217