### PR TITLE
Fix for Boxed variable is never null

### DIFF
--- a/src/java/com/puppetlabs/puppetserver/MetricsPuppetProfiler.java
+++ b/src/java/com/puppetlabs/puppetserver/MetricsPuppetProfiler.java
@@ -44,7 +44,7 @@ public class MetricsPuppetProfiler implements PuppetProfiler {
     @Override
     public void finish(Object context, String message, String[] metric_id) {
         if (shouldTime(metric_id)) {
-          Long elapsed = System.currentTimeMillis() - (Long)context;
+          long elapsed = System.currentTimeMillis() - (Long)context;
 	    Map<String, Timer> metricsByID = getOrCreateTimersByIDs(metric_id);
             for (Timer t : metricsByID.values()) {
                 t.update(elapsed, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Use a primitive `long` for the local `elapsed` variable in `finish(...)` instead of `Long`.

- **General fix**: When a local variable is never `null` and only holds primitive values, declare it as the corresponding primitive type.
- **Specific fix in this file**: In `src/java/com/puppetlabs/puppetserver/MetricsPuppetProfiler.java`, inside `finish(Object context, String message, String[] metric_id)`, change:
  - `Long elapsed = System.currentTimeMillis() - (Long)context;`
  - to
  - `long elapsed = System.currentTimeMillis() - (Long)context;`
- No import or dependency changes are required. Functionality remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._