### PR TITLE
remove unused build dependencies 

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -8,9 +8,10 @@ ezbake: {
    pe: {}
    foss: {
       redhat: { dependencies: ["openvox-agent >= 8.21.1"],
-                build-dependencies: ["%{open_jdk}"],
-                # Install some gems
-                install: ["bash ./ext/build-scripts/install-vendored-gems.sh"]
+              # we could add additional packages here
+              # build-dependencies: [""],
+              # Install some gems
+              install: ["bash ./ext/build-scripts/install-vendored-gems.sh"]
                # This is terrible, but we need write access to puppet's
                # var/conf dirs, so we need to add ourselves to the group.
                # Then we need to chmod some dirs until the Puppet packaging
@@ -35,7 +36,8 @@ ezbake: {
              }
 
       debian: { dependencies: ["openvox-agent (>= 8.21.1)"],
-                build-dependencies: ["openjdk-17-jre-headless"],
+                # we could add additional packages here
+                # build-dependencies: [""],
                 install: ["bash ./ext/build-scripts/install-vendored-gems.sh"]
                # see redhat comments on why this is terrible
                postinst-install: [


### PR DESCRIPTION
ezbake has a nice option do manage build dependencies. This pointed to legacy/random java. This isn't used at all in the moment, so we can remove it. The feature is hard to find and could be useful in the future, so I commented it out.

Signed-off-by: Tim Meusel <tim@bastelfreak.de>

---

also contains #252 