### PR TITLE
Remove FIPS BC jars from ezbake-fips dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -287,9 +287,6 @@
                                                     ;; The non-FIPS BC jar is only needed for installing vendored gems
                                                     ;; at packaging time, and is not included in the final package.
                                                     [org.bouncycastle/bcpkix-jdk18on]
-                                                    [org.bouncycastle/bc-fips]
-                                                    [org.bouncycastle/bcpkix-fips]
-                                                    [org.bouncycastle/bctls-fips]
                                                     [org.openvoxproject/jruby-utils]
                                                     ;; Do not modify this line. It is managed by the release process
                                                     ;; via the scripts/sync_ezbake_dep.rb script.


### PR DESCRIPTION
The FIPS BouncyCastle jars (bc-fips, bcpkix-fips, bctls-fips) cannot be in :ezbake-fips :dependencies alongside bcpkix-jdk18on because bc-fips has Sealed: true in its manifest and shares packages with bcprov-jdk18on (a transitive dependency of bcpkix-jdk18on), causing a JVM sealing violation at startup.

The FIPS jars remain in :managed-dependencies for version pinning and in :classpath-jars so ezbake copies them to staging. With the ezbake fallback for resolving classpath-jar artifacts from managed-dependencies, they no longer need to be in :dependencies.

Requires https://github.com/OpenVoxProject/ezbake/pull/94