### PR TITLE
project.clj: Readd -SNAPSHOT to version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -52,7 +52,7 @@
 
 ;; If you modify the version manually, run scripts/sync_ezbake_dep.rb to keep
 ;; the ezbake dependency in sync.
-(defproject org.openvoxproject/puppetserver "8.13.0"
+(defproject org.openvoxproject/puppetserver "8.13.0-SNAPSHOT"
   :description "OpenVox Server"
 
   :license {:name "Apache License, Version 2.0"
@@ -277,7 +277,7 @@
                                                [org.openvoxproject/jruby-utils]
                                                ;; Do not modify this line. It is managed by the release process
                                                ;; via the scripts/sync_ezbake_dep.rb script.
-                                               [org.openvoxproject/puppetserver "8.13.0"]
+                                               [org.openvoxproject/puppetserver "8.13.0-SNAPSHOT"]
                                                [org.openvoxproject/trapperkeeper-webserver-jetty10]
                                                [org.openvoxproject/trapperkeeper-metrics]]
                       :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.4")]]
@@ -290,7 +290,7 @@
                                                     [org.openvoxproject/jruby-utils]
                                                     ;; Do not modify this line. It is managed by the release process
                                                     ;; via the scripts/sync_ezbake_dep.rb script.
-                                                    [org.openvoxproject/puppetserver "8.13.0"]
+                                                    [org.openvoxproject/puppetserver "8.13.0-SNAPSHOT"]
                                                     [org.openvoxproject/trapperkeeper-webserver-jetty10]
                                                     [org.openvoxproject/trapperkeeper-metrics]]
                             :uberjar-exclusions [#"^org/bouncycastle/.*"]


### PR DESCRIPTION
our `lein release` workflow needs a version that ends with -SNAPSHOT. Since we want to kick of a release, readding this is easier than rewriting the task. Initially it was removed because we wanted to update the CHANGELOG.md

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
