### PR TITLE
Bugfixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ruby/puppet"]
 	path = ruby/puppet
-	url = https://github.com/openvoxproject/puppet.git
+	url = https://github.com/openvoxproject/openvox.git
 [submodule "ruby/hiera"]
 	path = ruby/hiera
 	url = https://github.com/openvoxproject/hiera.git
@@ -9,4 +9,4 @@
 	url = https://github.com/openvoxproject/puppet-resource_api.git
 [submodule "ruby/facter"]
 	path = ruby/facter
-	url = https://github.com/openvoxproject/facter.git
+	url = https://github.com/openvoxproject/openfact.git

--- a/Rakefile
+++ b/Rakefile
@@ -337,9 +337,9 @@ else
     config.user = 'openvoxproject'
     config.project = 'openvox-server'
     config.exclude_labels = %w[dependencies duplicate question invalid wontfix wont-fix modulesync skip-changelog]
-    # this is probably the worst way to do this
-    # ideally there would be a VERSION file and clojure and Rake would read it
-    config.future_release = '8.13.0'
+    config.future_release = File.readlines('project.clj')
+      .grep(/^\(defproject /).first[/"([^"]+)"/, 1]
+      .sub(/-SNAPSHOT\z/, '')
     # we limit the changelog to all new openvox releases, to skip perforce onces
     # otherwise the changelog generate takes a lot amount of time
     config.since_tag = '8.7.0'


### PR DESCRIPTION
### Fix stale submodule URLs in .gitmodules

Update ruby/puppet and ruby/facter submodule URLs to their canonical
names (openvox and openfact) instead of relying on GitHub redirects
from the old puppet.git and facter.git names.

### Return to reading config.future_release from project.clj dynamically

We hardcoded this for the last release since the old method broke. This
fixes it to look for the right line to find the version.