### PR TITLE
Migrate config to use trapperkeeper-webserver

### DIFF
--- a/dev/bootstrap.cfg
+++ b/dev/bootstrap.cfg
@@ -2,7 +2,7 @@ puppetlabs.services.request-handler.request-handler-service/request-handler-serv
 puppetlabs.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
 puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service/jruby-pool-manager-service
 puppetlabs.services.puppet-profiler.puppet-profiler-service/puppet-profiler-service
-puppetlabs.trapperkeeper.services.webserver.jetty10-service/jetty10-service
+puppetlabs.trapperkeeper.services.webserver.jetty-service/jetty-service
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 puppetlabs.services.config.puppet-server-config-service/puppet-server-config-service
 puppetlabs.services.master.master-service/master-service

--- a/dev/dev_tools.clj
+++ b/dev/dev_tools.clj
@@ -1,5 +1,5 @@
 (ns dev-tools
-  (:require [puppetlabs.trapperkeeper.services.webserver.jetty10-service :refer [jetty10-service]]
+  (:require [puppetlabs.trapperkeeper.services.webserver.jetty-service :refer [jetty-service]]
 
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :refer [webrouting-service]]
             [puppetlabs.services.master.master-service :refer [master-service]]

--- a/ext/thread_test/bootstrap.cfg
+++ b/ext/thread_test/bootstrap.cfg
@@ -2,7 +2,7 @@ puppetlabs.services.request-handler.request-handler-service/request-handler-serv
 puppetlabs.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
 puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service/jruby-pool-manager-service
 puppetlabs.services.puppet-profiler.puppet-profiler-service/puppet-profiler-service
-puppetlabs.trapperkeeper.services.webserver.jetty10-service/jetty10-service
+puppetlabs.trapperkeeper.services.webserver.jetty-service/jetty-service
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 puppetlabs.services.config.puppet-server-config-service/puppet-server-config-service
 puppetlabs.services.master.master-service/master-service

--- a/ezbake/system-config/services.d/bootstrap.cfg
+++ b/ezbake/system-config/services.d/bootstrap.cfg
@@ -2,7 +2,7 @@ puppetlabs.services.request-handler.request-handler-service/request-handler-serv
 puppetlabs.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
 puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service/jruby-pool-manager-service
 puppetlabs.services.puppet-profiler.puppet-profiler-service/puppet-profiler-service
-puppetlabs.trapperkeeper.services.webserver.jetty10-service/jetty10-service
+puppetlabs.trapperkeeper.services.webserver.jetty-service/jetty-service
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
 puppetlabs.services.config.puppet-server-config-service/puppet-server-config-service
 puppetlabs.services.master.master-service/master-service

--- a/project.clj
+++ b/project.clj
@@ -93,26 +93,26 @@
                          [org.bouncycastle/bctls-fips "1.0.19"]
                          [org.openvoxproject/clj-shell-utils "2.1.2"]
                          [org.openvoxproject/comidi "1.1.3"]
-                         [org.openvoxproject/http-client "2.2.8"]
+                         [org.openvoxproject/http-client "2.3.0"]
                          [org.openvoxproject/i18n ~i18n-version]
                          [org.openvoxproject/jruby-utils "5.3.8"]
                          [org.openvoxproject/kitchensink "3.5.7"]
                          [org.openvoxproject/kitchensink "3.5.7" :classifier "test"]
                          [org.openvoxproject/rbac-client "1.2.10"]
                          [org.openvoxproject/rbac-client "1.2.10" :classifier "test"]
-                         [org.openvoxproject/ring-middleware "2.1.8"]
+                         [org.openvoxproject/ring-middleware "2.2.0"]
                          [org.openvoxproject/ssl-utils "3.6.4"]
                          [org.openvoxproject/trapperkeeper "4.3.5"]
                          [org.openvoxproject/trapperkeeper "4.3.5" :classifier "test"]
-                         [org.openvoxproject/trapperkeeper-comidi-metrics "1.0.7"]
-                         [org.openvoxproject/trapperkeeper-authorization "2.1.10"]
+                         [org.openvoxproject/trapperkeeper-comidi-metrics "1.1.0"]
+                         [org.openvoxproject/trapperkeeper-authorization "2.2.0"]
                          [org.openvoxproject/trapperkeeper-filesystem-watcher "1.5.2"]
-                         [org.openvoxproject/trapperkeeper-metrics "2.1.11"]
-                         [org.openvoxproject/trapperkeeper-metrics "2.1.11" :classifier "test"]
+                         [org.openvoxproject/trapperkeeper-metrics "2.2.0"]
+                         [org.openvoxproject/trapperkeeper-metrics "2.2.0" :classifier "test"]
                          [org.openvoxproject/trapperkeeper-scheduler "1.3.2"]
-                         [org.openvoxproject/trapperkeeper-status "1.3.5"]
-                         [org.openvoxproject/trapperkeeper-webserver-jetty10 "1.1.8"]
-                         [org.openvoxproject/trapperkeeper-webserver-jetty10 "1.1.8" :classifier "test"]
+                         [org.openvoxproject/trapperkeeper-status "1.4.0"]
+                         [org.openvoxproject/trapperkeeper-webserver "10.0.0"]
+                         [org.openvoxproject/trapperkeeper-webserver "10.0.0" :classifier "test"]
                          [org.ow2.asm/asm "9.9.1"]
                          [org.slf4j/jul-to-slf4j ~slf4j-version]
                          [org.slf4j/log4j-over-slf4j ~slf4j-version]
@@ -153,7 +153,7 @@
                  [org.openvoxproject/trapperkeeper-metrics]
                  [org.openvoxproject/trapperkeeper-scheduler]
                  [org.openvoxproject/trapperkeeper-status]
-                 [org.openvoxproject/trapperkeeper-webserver-jetty10]
+                 [org.openvoxproject/trapperkeeper-webserver]
                  [org.yaml/snakeyaml]
                  [prismatic/schema]
                  [slingshot]]
@@ -206,7 +206,7 @@
 
   :profiles {:defaults {:source-paths  ["dev"]
                         :dependencies  [[org.clojure/tools.namespace]
-                                        [org.openvoxproject/trapperkeeper-webserver-jetty10 :classifier "test"]
+                                        [org.openvoxproject/trapperkeeper-webserver :classifier "test"]
                                         [org.openvoxproject/trapperkeeper :classifier "test" :scope "test"]
                                         [org.openvoxproject/trapperkeeper-metrics :classifier "test" :scope "test"]
                                         [org.openvoxproject/kitchensink :classifier "test" :scope "test"]
@@ -278,7 +278,7 @@
                                                ;; Do not modify this line. It is managed by the release process
                                                ;; via the scripts/sync_ezbake_dep.rb script.
                                                [org.openvoxproject/puppetserver "8.14.0-SNAPSHOT"]
-                                               [org.openvoxproject/trapperkeeper-webserver-jetty10]
+                                               [org.openvoxproject/trapperkeeper-webserver]
                                                [org.openvoxproject/trapperkeeper-metrics]]
                       :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.5")]]
                       :name "puppetserver"}
@@ -291,18 +291,18 @@
                                                     ;; Do not modify this line. It is managed by the release process
                                                     ;; via the scripts/sync_ezbake_dep.rb script.
                                                     [org.openvoxproject/puppetserver "8.14.0-SNAPSHOT"]
-                                                    [org.openvoxproject/trapperkeeper-webserver-jetty10]
+                                                    [org.openvoxproject/trapperkeeper-webserver]
                                                     [org.openvoxproject/trapperkeeper-metrics]]
                             :uberjar-exclusions [#"^org/bouncycastle/.*"]
                             :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.5")]]
                       :name "puppetserver"}
-             :uberjar {:dependencies [[org.openvoxproject/trapperkeeper-webserver-jetty10]]
+             :uberjar {:dependencies [[org.openvoxproject/trapperkeeper-webserver]]
                        :aot [puppetlabs.trapperkeeper.main
                              puppetlabs.trapperkeeper.services.status.status-service
                              puppetlabs.trapperkeeper.services.metrics.metrics-service
                              puppetlabs.services.protocols.jruby-puppet
                              puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service
-                             puppetlabs.trapperkeeper.services.webserver.jetty10-service
+                             puppetlabs.trapperkeeper.services.webserver.jetty-service
                              puppetlabs.trapperkeeper.services.webrouting.webrouting-service
                              puppetlabs.services.legacy-routes.legacy-routes-core
                              puppetlabs.services.protocols.jruby-metrics

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -24,7 +24,7 @@ rpm_fips, rpm_nonfips = rpm_platforms.split(',').partition { |p| p.start_with?('
 @fips_rpms = rpm_fips.map{ |p| "pl-#{p}-x86_64" }.join(' ')
 
 # The deps must be built in this order due to dependencies between them.
-# There is a circular dependency between clj-http-client and trapperkeeper-webserver-jetty10,
+# There is a circular dependency between clj-http-client and trapperkeeper-webserver,
 # but only for tests, so the build *should* work.
 DEP_BUILD_ORDER = [
   'clj-kitchensink',
@@ -36,11 +36,10 @@ DEP_BUILD_ORDER = [
   'trapperkeeper',
   'trapperkeeper-filesystem-watcher',
   'clj-http-client',
-  'trapperkeeper-webserver-jetty10',
+  'trapperkeeper-webserver',
   'ring-middleware',
   'jruby-utils',
   'clj-shell-utils',
-  'clj-rbac-client',
   'trapperkeeper-authorization',
   'trapperkeeper-metrics',
   'trapperkeeper-scheduler',

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -7,7 +7,7 @@
             [puppetlabs.puppetserver.testutils :as testutils]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-bootstrap-testutils]
-            [puppetlabs.trapperkeeper.testutils.webserver :as jetty10]
+            [puppetlabs.trapperkeeper.testutils.webserver :as jetty]
             [puppetlabs.services.master.master-core :as master-core]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [cheshire.core :as cheshire]
@@ -617,7 +617,7 @@
                   (apply str (repeat body-length "a"))
                   expected-etag))
                (master-core/wrap-with-cache-check jruby-service))]
-      (jetty10/with-test-webserver
+      (jetty/with-test-webserver
        app
        port
        (let [request-url (str "http://localhost:" port)

--- a/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_transports_int_test.clj
@@ -6,7 +6,7 @@
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.puppetserver.testutils :as testutils]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-bootstrap-testutils]
-            [puppetlabs.trapperkeeper.testutils.webserver :as jetty10]
+            [puppetlabs.trapperkeeper.testutils.webserver :as jetty]
             [puppetlabs.services.master.master-core :as master-core]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [cheshire.core :as json]
@@ -487,7 +487,7 @@ Puppet::ResourceApi.register_transport(
                   (apply str (repeat body-length "a"))
                   expected-etag))
                (master-core/wrap-with-cache-check jruby-service))]
-      (jetty10/with-test-webserver
+      (jetty/with-test-webserver
        app
        port
        (let [request-url (str "http://localhost:" port)

--- a/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
+++ b/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
@@ -8,7 +8,7 @@
            (java.util.zip GZIPInputStream))
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
-            [puppetlabs.trapperkeeper.testutils.webserver :as jetty10]
+            [puppetlabs.trapperkeeper.testutils.webserver :as jetty]
             [puppetlabs.services.jruby.jruby-puppet-testutils :as jruby-puppet-testutils]
             [ring.middleware.basic-authentication :as auth]
             [schema.core :as schema]
@@ -170,7 +170,7 @@
 (use-fixtures :once http-client-scripting-container-fixture)
 
 (deftest test-ruby-http-client
-  (jetty10/with-test-webserver ring-app port
+  (jetty/with-test-webserver ring-app port
     (with-scripting-container sc
       (with-http-client sc {}
         (let [url (str "http://localhost:" port)]
@@ -180,7 +180,7 @@
             (is (= "hi" (.runScriptlet sc (format "$c.post(URI('%s'), 'foo').body" url))))))))))
 
 (deftest http-escaped-urls-test
-  (jetty10/with-test-webserver ring-app port
+  (jetty/with-test-webserver ring-app port
     (with-scripting-container sc
       (with-http-client sc {}
         (let [url (str "http://localhost:" port)]
@@ -190,7 +190,7 @@
             (is (= (str url "/a%20b%3Fc?foo=bar") (.runScriptlet sc "$response.url.to_s")))))))))
 
 (deftest http-basic-auth
-  (jetty10/with-test-webserver ring-app-with-auth port
+  (jetty/with-test-webserver ring-app-with-auth port
     (with-scripting-container sc
       (with-http-client sc {}
         (let [url (str "http://localhost:" port)]
@@ -213,7 +213,7 @@
             (is (= "access denied" (.runScriptlet sc "$response.body")))))))))
 
 (deftest http-compressed-requests
-  (jetty10/with-test-webserver ring-app-decompressing-gzipped-request port
+  (jetty/with-test-webserver ring-app-decompressing-gzipped-request port
     (with-scripting-container sc
       (with-http-client sc {}
         (let [url (str "http://localhost:" port)]
@@ -244,7 +244,7 @@
 
 (defmacro with-webserver-with-protocols
   [protocols cipher-suites & body]
-  `(jetty10/with-test-webserver-and-config ring-app port#
+  `(jetty/with-test-webserver-and-config ring-app port#
     (merge {:ssl-host    "localhost"
             :ssl-port    10080
             :ssl-ca-cert ca-pem
@@ -304,7 +304,7 @@
 (deftest clients-persist
   (testing "client persists when making HTTP requests"
     (logutils/with-test-logging
-      (jetty10/with-test-webserver ring-app port
+      (jetty/with-test-webserver ring-app port
         (with-scripting-container sc
           (with-http-client sc {}
             (let [url (str "http://localhost:" port)
@@ -313,7 +313,7 @@
               (is (= client1 client2))))))))
   (testing "all instances of HttpClient have the same underlying client object"
     (logutils/with-test-logging
-      (jetty10/with-test-webserver ring-app port
+      (jetty/with-test-webserver ring-app port
         (with-scripting-container sc
           (with-http-client sc {}
             (let [client1 (.runScriptlet sc "$c.class.client")
@@ -324,7 +324,7 @@
 (deftest connections-closed
   (testing "connection header always set to close on get"
     (logutils/with-test-logging
-      (jetty10/with-test-webserver ring-app-connection-closed port
+      (jetty/with-test-webserver ring-app-connection-closed port
         (with-scripting-container sc
           (with-http-client sc {}
             (let [url (str "http://localhost:" port)]
@@ -332,7 +332,7 @@
                      (.runScriptlet sc (format "$c.get(URI('%s')).body" url))))))))))
   (testing "connection header always set to close on post"
     (logutils/with-test-logging
-      (jetty10/with-test-webserver ring-app-connection-closed port
+      (jetty/with-test-webserver ring-app-connection-closed port
         (with-scripting-container sc
           (with-http-client sc {}
             (let [url (str "http://localhost:" port)]
@@ -340,7 +340,7 @@
                      (.runScriptlet sc (format "$c.post(URI('%s'), 'foo').body" url))))))))))
   (testing "client's terminate function closes the client"
     (logutils/with-test-logging
-      (jetty10/with-test-webserver ring-app-connection-closed port
+      (jetty/with-test-webserver ring-app-connection-closed port
         (with-scripting-container sc
           (with-http-client sc {}
             (let [url (str "http://localhost:" port)]
@@ -358,7 +358,7 @@
 (deftest http-and-https
   (testing "can make http calls after https calls without a new scripting container"
     (logutils/with-test-logging
-      (jetty10/with-test-webserver ring-app-alternate port
+      (jetty/with-test-webserver ring-app-alternate port
         (with-webserver-with-protocols nil nil
           (with-scripting-container sc
             (with-http-client sc {}
@@ -373,7 +373,7 @@
 
   (testing "can make https calls after http calls without a new scripting container"
     (logutils/with-test-logging
-      (jetty10/with-test-webserver ring-app-alternate port
+      (jetty/with-test-webserver ring-app-alternate port
         (with-webserver-with-protocols nil nil
           (with-scripting-container sc
             (with-http-client sc {}

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_testutils.clj
@@ -13,7 +13,7 @@
             [puppetlabs.trapperkeeper.services.metrics.metrics-service :as metrics]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby-puppet]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
-            [puppetlabs.trapperkeeper.services.webserver.jetty10-service :as jetty10-service]
+            [puppetlabs.trapperkeeper.services.webserver.jetty-service :as jetty-service]
             [puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service :as jruby-pool-manager]
             [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :as scheduler-service]
             [puppetlabs.trapperkeeper.services.status.status-service :as status-service]
@@ -46,7 +46,7 @@
    metrics/metrics-service
    scheduler-service/scheduler-service
    status-service/status-service
-   jetty10-service/jetty10-service
+   jetty-service/jetty-service
    webrouting-service/webrouting-service])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/unit/puppetlabs/services/puppet_profiler/puppet_profiler_service_test.clj
+++ b/test/unit/puppetlabs/services/puppet_profiler/puppet_profiler_service_test.clj
@@ -2,7 +2,7 @@
   (:import (com.puppetlabs.puppetserver PuppetProfiler))
   (:require [clojure.test :refer [deftest is testing]]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :refer [puppet-profiler-service]]
-            [puppetlabs.trapperkeeper.services.webserver.jetty10-service :as jetty10-service]
+            [puppetlabs.trapperkeeper.services.webserver.jetty-service :as jetty-service]
             [puppetlabs.trapperkeeper.services.metrics.metrics-service :as metrics-service]
             [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :as scheduler-service]
             [puppetlabs.trapperkeeper.services.status.status-service :as status-service]
@@ -16,7 +16,7 @@
   (bootstrap/with-app-with-config
     app
     [puppet-profiler-service
-     jetty10-service/jetty10-service
+     jetty-service/jetty-service
      metrics-service/metrics-service
      scheduler-service/scheduler-service
      status-service/status-service

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -16,7 +16,7 @@
             [puppetlabs.puppetserver.bootstrap-testutils :as jruby-bootstrap]
             [puppetlabs.services.protocols.versioned-code :as vc]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
-            [puppetlabs.trapperkeeper.services.webserver.jetty10-service :as jetty10]
+            [puppetlabs.trapperkeeper.services.webserver.jetty-service :as jetty]
             [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :as tk-scheduler]
             [puppetlabs.services.request-handler.request-handler-service :as handler-service]
             [puppetlabs.services.config.puppet-server-config-service :as ps-config]
@@ -324,7 +324,7 @@
                      profiler/puppet-profiler-service
                      handler-service/request-handler-service
                      ps-config/puppet-server-config-service
-                     jetty10/jetty10-service
+                     jetty/jetty-service
                      ca-service/certificate-authority-service
                      authorization-service/authorization-service
                      routing-service/webrouting-service


### PR DESCRIPTION
We removed the 'Jetty10' from the repo and component name, as well as classes and service names.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
