### PR TITLE
Use Ruby 4 for builder image and cache it

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -96,10 +96,26 @@ jobs:
       - name: setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '4.0'
           bundler-cache: true
-      # uses the Dockerfile to build openvox-server in a container
-      # the container hardcodes the java version
+      - id: docker-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/ezbake-builder.tar
+          key: docker-ezbake-${{ hashFiles('Dockerfile') }}
+      - name: load or build docker image
+        run: |
+          if [[ -f /tmp/ezbake-builder.tar ]]; then
+            docker load -i /tmp/ezbake-builder.tar
+          else
+            docker build -t ezbake-builder .
+            docker save ezbake-builder -o /tmp/ezbake-builder.tar
+          fi
+      - uses: actions/cache/save@v4
+        if: always() && steps.docker-cache.outputs.cache-hit != 'true'
+        with:
+          path: /tmp/ezbake-builder.tar
+          key: docker-ezbake-${{ hashFiles('Dockerfile') }}
       - name: build it
         run: bundle exec rake vox:build
       - name: get version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,16 @@
-FROM almalinux:9
+FROM ruby:4.0-bookworm
 
-WORKDIR /
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      openjdk-17-jdk-headless \
+      rpm \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN dnf install -y --enablerepo=crb vim wget git rpm-build java-17-openjdk java-17-openjdk-devel libyaml-devel zlib zlib-devel gcc-c++ patch readline readline-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison sqlite-devel
-RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
-RUN chmod a+x lein
-RUN mv lein /usr/local/bin
-RUN wget -q https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer -O- | bash
-# todo: it would be great if we could get the used ruby version from openvox-agent and use it here
-# and maybe don't randomly download rbenv and leiningen
-# and how bad is it that we hardcode java 11 above?
-RUN /bin/bash --login -c 'rbenv install 3.2.9'
-RUN /bin/bash --login -c 'rbenv global 3.2.9'
-RUN git config --global user.email "openvox@voxpupuli.org"
-RUN git config --global user.name "Vox Pupuli"
-RUN git config --global --add safe.directory /code
+RUN wget -q https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -O /usr/local/bin/lein && \
+    chmod a+x /usr/local/bin/lein
 
-CMD ["tail -f /dev/null"]
+RUN git config --global user.email "openvox@voxpupuli.org" && \
+    git config --global user.name "Vox Pupuli" && \
+    git config --global --add safe.directory /code
+
+CMD ["tail", "-f", "/dev/null"]

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
   :license {:name "Apache License, Version 2.0"
               :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
-  :min-lein-version "2.9.1"
+  :min-lein-version "2.12.0"
 
   ;; Generally, try to keep version pins in :managed-dependencies and the libraries
   ;; this project actually uses in :dependencies, inheriting the version from

--- a/project.clj
+++ b/project.clj
@@ -249,7 +249,7 @@
                                                [org.openvoxproject/puppetserver "9.0.0-SNAPSHOT"]
                                                [org.openvoxproject/trapperkeeper-webserver]
                                                [org.openvoxproject/trapperkeeper-metrics]]
-                      :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.5")]]
+                      :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.6")]]
                       :name "puppetserver"}
 
              :ezbake-fips {:dependencies ^:replace [[org.clojure/clojure]
@@ -263,7 +263,7 @@
                                                     [org.openvoxproject/trapperkeeper-webserver]
                                                     [org.openvoxproject/trapperkeeper-metrics]]
                             :uberjar-exclusions [#"^org/bouncycastle/.*"]
-                            :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.5")]]
+                            :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.6")]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.openvoxproject/trapperkeeper-webserver]]
                        :aot [puppetlabs.trapperkeeper.main

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -144,7 +144,7 @@ namespace :vox do
 
       puts "Building openvox-server"
       ezbake_version_var = ENV['EZBAKE_VERSION'] ? "EZBAKE_VERSION=#{ENV['EZBAKE_VERSION']}" : ''
-      run("cd /code && rm -rf output && bundle install --without test && lein install")
+      run("cd /code && rm -rf output && bundle config set without test && bundle install && lein install")
 
       unless @debs.empty? && @nonfips_rpms.empty?
         run("cd /code && COW=\"#{@debs}\" MOCK=\"#{@nonfips_rpms}\" GEM_SOURCE='https://rubygems.org' #{ezbake_version_var} EZBAKE_ALLOW_UNREPRODUCIBLE_BUILDS=true EZBAKE_NODEPLOY=true LEIN_PROFILES=ezbake lein with-profile user,ezbake,provided ezbake local-build")


### PR DESCRIPTION
Rather than recreate the builder container every time using rbenv, which takes quite a while, this uses the off-the-shell Ruby 4 Bookworm image. It also caches the image in GitHub for the PR job that tests the build.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
