### PR TITLE
Fix cli logback config

### DIFF
--- a/resources/ext/cli/gem.erb
+++ b/resources/ext/cli/gem.erb
@@ -16,13 +16,13 @@ fi
 
 LOGBACK_CONFIG="${CONFIG%/conf.d}/logback.xml"
 if [ -f "${LOGBACK_CONFIG}" ]; then
-    LOGBACK_JAVA_ARG="-Dlogback.configurationFile=${LOGBACK_CONFIG}"
+    LOGBACK_JAVA_ARGS="-Dlogback.configurationFile=${LOGBACK_CONFIG} -Dlogappender=F1"
 else
-    LOGBACK_JAVA_ARG="-Dlogback.statusListenerClass=ch.qos.logback.core.status.NopStatusListener"
+    LOGBACK_JAVA_ARGS="-Dlogback.statusListenerClass=ch.qos.logback.core.status.NopStatusListener"
 fi
 
 "${JAVA_BIN}" $JAVA_ARGS_CLI \
-    "${LOGBACK_JAVA_ARG}" \
+    ${LOGBACK_JAVA_ARGS} \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.gem \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/gem.erb
+++ b/resources/ext/cli/gem.erb
@@ -9,12 +9,20 @@ CLASSPATH=${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>
 if [ -e "$cli_defaults" ]; then
   . $cli_defaults
   if [ $? -ne 0 ]; then
-    echo "Unable to initialize cli defaults, failing irb subcommand." 1>&2
+    echo "Unable to initialize cli defaults, failing gem subcommand." 1>&2
     exit 1
   fi
 fi
 
+LOGBACK_CONFIG="${CONFIG%/conf.d}/logback.xml"
+if [ -f "${LOGBACK_CONFIG}" ]; then
+    LOGBACK_JAVA_ARG="-Dlogback.configurationFile=${LOGBACK_CONFIG}"
+else
+    LOGBACK_JAVA_ARG="-Dlogback.statusListenerClass=ch.qos.logback.core.status.NopStatusListener"
+fi
+
 "${JAVA_BIN}" $JAVA_ARGS_CLI \
+    "${LOGBACK_JAVA_ARG}" \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.gem \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/irb.erb
+++ b/resources/ext/cli/irb.erb
@@ -14,13 +14,13 @@ fi
 
 LOGBACK_CONFIG="${CONFIG%/conf.d}/logback.xml"
 if [ -f "${LOGBACK_CONFIG}" ]; then
-    LOGBACK_JAVA_ARG="-Dlogback.configurationFile=${LOGBACK_CONFIG}"
+    LOGBACK_JAVA_ARGS="-Dlogback.configurationFile=${LOGBACK_CONFIG} -Dlogappender=F1"
 else
-    LOGBACK_JAVA_ARG="-Dlogback.statusListenerClass=ch.qos.logback.core.status.NopStatusListener"
+    LOGBACK_JAVA_ARGS="-Dlogback.statusListenerClass=ch.qos.logback.core.status.NopStatusListener"
 fi
 
 "${JAVA_BIN}" $JAVA_ARGS_CLI \
-    "${LOGBACK_JAVA_ARG}" \
+    ${LOGBACK_JAVA_ARGS} \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.irb \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/irb.erb
+++ b/resources/ext/cli/irb.erb
@@ -12,7 +12,15 @@ if [ -e "$cli_defaults" ]; then
   fi
 fi
 
+LOGBACK_CONFIG="${CONFIG%/conf.d}/logback.xml"
+if [ -f "${LOGBACK_CONFIG}" ]; then
+    LOGBACK_JAVA_ARG="-Dlogback.configurationFile=${LOGBACK_CONFIG}"
+else
+    LOGBACK_JAVA_ARG="-Dlogback.statusListenerClass=ch.qos.logback.core.status.NopStatusListener"
+fi
+
 "${JAVA_BIN}" $JAVA_ARGS_CLI \
+    "${LOGBACK_JAVA_ARG}" \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.irb \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/ruby.erb
+++ b/resources/ext/cli/ruby.erb
@@ -14,13 +14,13 @@ fi
 
 LOGBACK_CONFIG="${CONFIG%/conf.d}/logback.xml"
 if [ -f "${LOGBACK_CONFIG}" ]; then
-    LOGBACK_JAVA_ARG="-Dlogback.configurationFile=${LOGBACK_CONFIG}"
+    LOGBACK_JAVA_ARGS="-Dlogback.configurationFile=${LOGBACK_CONFIG} -Dlogappender=F1"
 else
-    LOGBACK_JAVA_ARG="-Dlogback.statusListenerClass=ch.qos.logback.core.status.NopStatusListener"
+    LOGBACK_JAVA_ARGS="-Dlogback.statusListenerClass=ch.qos.logback.core.status.NopStatusListener"
 fi
 
 "${JAVA_BIN}" $JAVA_ARGS_CLI \
-    "${LOGBACK_JAVA_ARG}" \
+    ${LOGBACK_JAVA_ARGS} \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.ruby \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/ruby.erb
+++ b/resources/ext/cli/ruby.erb
@@ -7,12 +7,20 @@ CLASSPATH=${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>
 if [ -e "$cli_defaults" ]; then
   . $cli_defaults
   if [ $? -ne 0 ]; then
-    echo "Unable to initialize cli defaults, failing irb subcommand." 1>&2
+    echo "Unable to initialize cli defaults, failing ruby subcommand." 1>&2
     exit 1
   fi
 fi
 
+LOGBACK_CONFIG="${CONFIG%/conf.d}/logback.xml"
+if [ -f "${LOGBACK_CONFIG}" ]; then
+    LOGBACK_JAVA_ARG="-Dlogback.configurationFile=${LOGBACK_CONFIG}"
+else
+    LOGBACK_JAVA_ARG="-Dlogback.statusListenerClass=ch.qos.logback.core.status.NopStatusListener"
+fi
+
 "${JAVA_BIN}" $JAVA_ARGS_CLI \
+    "${LOGBACK_JAVA_ARG}" \
     -cp "$CLASSPATH" \
     clojure.main -m puppetlabs.puppetserver.cli.ruby \
     --config "${CONFIG}" -- "$@"


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
Logback 1.5.x validates whether the configuration file is watchable
when scan="true" is set, as opposed to 1.3.x where it just validated the config variable was set. When auto-discovered from inside the uberjar, the JAR URL fails this check and logback emits WARN-level status
messages which trigger auto-printing of all status messages to stdout.
This pollutes the output of CLI subcommands (ruby, gem, irb) and
breaks any tool that parses their stdout.

Point logback at the installed logback.xml on disk via
-Dlogback.configurationFile so it uses the same config as the server
and can watch the file without warnings. Fall back to NopStatusListener
if the file does not exist (e.g. development environments). Also set
the logappender to F1 so it is pointing to the real log.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
