### PR TITLE
Remove scan="true" from logback.xml files that end up inside JARs

### DIFF
--- a/dev-resources/logback-test.xml
+++ b/dev-resources/logback-test.xml
@@ -1,4 +1,4 @@
-<configuration scan="true">
+<configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %-5p [%t] [%c{2}] %m%n</pattern>

--- a/dev-resources/puppetlabs/services/jruby/jruby_pool_int_test/logback-test-restart-comes-back.xml
+++ b/dev-resources/puppetlabs/services/jruby/jruby_pool_int_test/logback-test-restart-comes-back.xml
@@ -1,4 +1,4 @@
-<configuration scan="true">
+<configuration>
     <appender name="F1" class="ch.qos.logback.core.FileAppender">
         <file>./target/test-restart-comes-back.log</file>
         <append>true</append>

--- a/dev-resources/puppetlabs/services/master/environment_classes_int_test/logback-environment-classes-integration-cache-enabled-test.xml
+++ b/dev-resources/puppetlabs/services/master/environment_classes_int_test/logback-environment-classes-integration-cache-enabled-test.xml
@@ -1,4 +1,4 @@
-<configuration scan="true">
+<configuration>
     <appender name="F1" class="ch.qos.logback.core.FileAppender">
         <file>./target/environment-classes-integration-cache-enabled.log</file>
         <append>true</append>

--- a/dev/logback-dev.xml
+++ b/dev/logback-dev.xml
@@ -1,4 +1,4 @@
-<configuration scan="true">
+<configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %-5p [%t] [%c{2}] %m%n</pattern>


### PR DESCRIPTION
Some of these files end up inside the package due to leiningen scooping up everything in dev-resources in the :base profile. If they end up being found and used during server startup rather than files on disk (such as during builds and tests), they can't be watched with scan="true" since they are read-only inside the JAR. Logback 1.5 will then log directly to stdout which we don't want. We only need scan="true" for files that get laid down by the openvox-server and openvoxdb packages. To be safe, we are removing scan="true" from all logback.xml files in all repos.

The file that is actually laid down by the openvox-server package is ezbake/config/logback.xml, so it remains in that one.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
