### PR TITLE
add jruby-openssl 0.16.0 to vendored gems

### DIFF
--- a/resources/ext/build-scripts/jruby-stdlib-gem-list.txt
+++ b/resources/ext/build-scripts/jruby-stdlib-gem-list.txt
@@ -1,3 +1,4 @@
+jruby-openssl 0.16.0
 matrix 0.4.3
 minitest 5.26.2
 net-ftp 0.3.9


### PR DESCRIPTION

#### Pull Request (PR) description
- the bundled gem from jruby-stdlib is 0.15.4 which has compatibilty issues with bouncy castle 1.84

#### This Pull Request (PR) fixes the following issues
Fixes #322
