### PR TITLE
Revert "Use Ruby 4 for builder image and cache it"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-FROM ruby:4.0-bookworm
+FROM almalinux:9
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      openjdk-17-jdk-headless \
-      rpm \
-    && rm -rf /var/lib/apt/lists/*
+WORKDIR /
 
-RUN wget -q https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -O /usr/local/bin/lein && \
-    chmod a+x /usr/local/bin/lein
-
+RUN dnf install -y --enablerepo=crb vim wget git rpm-build java-17-openjdk java-17-openjdk-devel libyaml-devel zlib zlib-devel gcc-c++ patch readline readline-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison sqlite-devel
+RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
+RUN chmod a+x lein
+RUN mv lein /usr/local/bin
+RUN wget -q https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer -O- | bash
+# todo: it would be great if we could get the used ruby version from openvox-agent and use it here
+# and maybe don't randomly download rbenv and leiningen
+# and how bad is it that we hardcode java 11 above?
+RUN /bin/bash --login -c 'rbenv install 3.2.9'
+RUN /bin/bash --login -c 'rbenv global 3.2.9'
 RUN git config --global user.email "openvox@voxpupuli.org" && \
     git config --global user.name "Vox Pupuli" && \
     git config --global --add safe.directory /code


### PR DESCRIPTION
This partially reverts commit 269825e8916acb3a982c05c44d5cf9b21b230363.

The commit switched from an almalinux base to debian. For working rpm packages, we need rpm macros. They aren't packaged on debian. the rpm build will work, but installation will fail:

```
usermod: no changes
/var/tmp/rpm-tmp.S32ibD: line 9: fg: no job control
warning: %post(openvox-server-9.0.0-0.1SNAPSHOT.2026.05.27T2308.el9.noarch) scriptlet failed, exit status 1
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
