### PR TITLE
build: Switch to alma 10 / Java 21 / system Ruby

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         javaargs: ['with-profile fips', '']
         filter: [':singlethreaded', ':multithreaded']
-        version: ['17', '21']
+        version: ['21']
         exclude:
           - javaargs: 'with-profile fips'
             version: '21'
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['17', '21']
+        java: ['21']
         ruby: ['3.1', '3.2', '3.3', '3.4', '4.0']
     steps:
       - name: checkout repo
@@ -96,7 +96,7 @@ jobs:
       - name: setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0'
+          ruby-version: '3.3' # should match the Ruby used in Dockerfile. Currently Ruby 3.3 from Alma 10
           bundler-cache: true
       - id: docker-cache
         uses: actions/cache/restore@v5
@@ -161,7 +161,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: checkout repo
         uses: actions/checkout@v6
       # newer versions cause lint errors

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,11 @@
-FROM almalinux:9
+FROM almalinux:10
 
 WORKDIR /
 
-RUN dnf install -y --enablerepo=crb vim wget git rpm-build java-17-openjdk java-17-openjdk-devel libyaml-devel zlib zlib-devel gcc-c++ patch readline readline-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison sqlite-devel
+RUN dnf install -y --enablerepo=crb vim wget git rpm-build java-21-openjdk-devel libyaml-devel zlib zlib-devel gcc-c++ patch readline readline-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison sqlite-devel ruby
 RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
 RUN chmod a+x lein
 RUN mv lein /usr/local/bin
-RUN wget -q https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer -O- | bash
-# todo: it would be great if we could get the used ruby version from openvox-agent and use it here
-# and maybe don't randomly download rbenv and leiningen
-# and how bad is it that we hardcode java 11 above?
-RUN /bin/bash --login -c 'rbenv install 3.2.9'
-RUN /bin/bash --login -c 'rbenv global 3.2.9'
 RUN git config --global user.email "openvox@voxpupuli.org" && \
     git config --global user.name "Vox Pupuli" && \
     git config --global --add safe.directory /code

--- a/project.clj
+++ b/project.clj
@@ -249,7 +249,7 @@
                                                [org.openvoxproject/puppetserver "9.0.0-SNAPSHOT"]
                                                [org.openvoxproject/trapperkeeper-webserver]
                                                [org.openvoxproject/trapperkeeper-metrics]]
-                      :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.7")]]
+                      :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.8")]]
                       :name "puppetserver"}
 
              :ezbake-fips {:dependencies ^:replace [[org.clojure/clojure]
@@ -263,7 +263,7 @@
                                                     [org.openvoxproject/trapperkeeper-webserver]
                                                     [org.openvoxproject/trapperkeeper-metrics]]
                             :uberjar-exclusions [#"^org/bouncycastle/.*"]
-                            :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.7")]]
+                            :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.7.8")]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.openvoxproject/trapperkeeper-webserver]]
                        :aot [puppetlabs.trapperkeeper.main


### PR DESCRIPTION
This:
* Updates our build container from alma 9 to alma 10
* compiles openvox-server with java 21 instead of 17 (21 is required for future jruby versions)
* uses latest system ruby instead of compiling it
* drop java 17 from CI matrix
* updates to latest ezbake (required for building on EL10 hosts - https://github.com/OpenVoxProject/ezbake/pull/102 )