### PR TITLE
Provide --format='{{json .ID}}' when listing docker images.

### DIFF
--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -48,7 +48,7 @@ DEP_BUILD_ORDER = [
 ].freeze
 
 def image_exists
-  !`docker images -q #{@image}`.strip.empty?
+  !`docker images -q #{@image} --format='{{json .ID}}'`.strip.empty?
 end
 
 def container_exists


### PR DESCRIPTION
Split https://github.com/OpenVoxProject/openvox-server/pull/227.

This CL contains just the `--format='{{json .ID}'` argument, which is understood by both docker and podman.
It excludes replacing `docker` with the shell conditional `${DOCKER_BIN-docker}`.
