### PR TITLE
fix: README cursive clojure link

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Distributed under the [Apache License, Version
 
 ### Cursive Clojure
 
-[Cursive](https://cursiveclojure.com/) is a Clojure IDE based on [IntelliJ
+[Cursive](https://cursive-ide.com/) is a Clojure IDE based on [IntelliJ
 IDEA](http://www.jetbrains.com/idea/download/index.html). Several of us at
 Puppet use it regularly and couldn't live without it. It's got some really great
 editing, refactoring, and debugging features, and the author, Colin Fleming, has


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description

Actually the link to the cursive IDE point to a chinese marketplace ...
