### PR TITLE
Dockerfile: Dont install vim & Replace java-21-openjdk-devel->java-21-openjdk-headless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN dnf install -y --enablerepo=crb \
     cpio \
     gcc-c++ \
     git \
-    java-21-openjdk-devel \
+    java-21-openjdk-headless \
     libffi-devel \
     libtool \
     libyaml-devel \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN dnf install -y --enablerepo=crb \
     rpm-build \
     ruby \
     sqlite-devel \
-    vim \
     wget \
     zlib \
     zlib-devel


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
