### PR TITLE
Readd workflow to backport PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,23 @@
+---
+name: Backport merged pull request
+on:
+  pull_request_target:
+    types: [labeled]
+permissions:
+  contents: write      # so it can comment
+  pull-requests: write # so it can create pull requests
+jobs:
+  backport:
+    name: Backport merged pull request
+    runs-on: ubuntu-latest
+    # For security reasons, we don't want to checkout and run arbitrary code when
+    # using the pull_request_target trigger. So restrict this to cases where the
+    # backport label is applied to an already merged PR.
+    if: github.event.pull_request.merged && contains(github.event.label.name, 'backport')
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Create backport pull requests
+        uses: korthout/backport-action@66065406958f46e82238fd59546f5a99e69e22aa # v4.5.2
+        with:
+          auto_merge_enabled: true
+          auto_merge_method: merge


### PR DESCRIPTION
We used this previously to backport changes to the 7.x branch. We can use it again for the 8.x branch. If a PR gets the `backport 8.x` label and gets merged, the commit(s) will be cherry-picked and provided as a new PR, to the 8.x branch.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
