### PR TITLE
Bump Beaker dependency to ~>6.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'rake', :group => [:development, :test]
 
 group :test do
   gem 'rspec'
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 6.0')
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 6.8')
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "< 4")
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || "~> 4.0")
   gem 'uuidtools'


### PR DESCRIPTION
#### Pull Request (PR) description

For some reason, `bundle install` in acceptance pipelines is deciding to install Beaker 6.6.0 instead of the 6.8.1 used by the `openvox` agent acceptance suites.

The 6.6.0 version is missing a critical fix that prevents Beaker from mis-classifying `el-10` as `el-1` and falling back to SysV service management commands:

  voxpupuli/beaker@400af53c2

This fails acceptance tests on Alma Linux 10 as that distro does not install the SysV shims by default.

This commit updates the pin from `~>6.0` to `~>6.8` which forces dependency resolution to pick the 6.8.1 version.
