### PR TITLE
acceptance: Update PostgreSQL repo configuration

### DIFF
--- a/acceptance/suites/pre_suite/foss/95_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/95_install_pdb.rb
@@ -14,10 +14,7 @@ end
 step 'Update EL postgresql repos' do
   # work around for testing on rhel and the repos on the image not finding the pg packages it needs
   if master.platform =~ /el-/
-    major_version = case master.platform
-      when /-8/ then 8
-      when /-9/ then 9
-      end
+    major_version = host.platform.split('-')[1]
 
     on master, "dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-#{major_version}-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
     on master, "dnf -qy module disable postgresql"


### PR DESCRIPTION
#### Pull Request (PR) description

The acceptance suite sets up the postgresql.org repos as part of installing OpenVoxDB. However, the setup logic for EL systems is special-cased, requiring a separate branch to be added for each new EL release just to determine the version number to use.

This commit replaces that `case` with the logic from the OpenVoxDB acceptance suite which just splits the platform name on `-` and takes the second component as the version number.
