### PR TITLE
Backport: Bump Beaker dependency to ~>6.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'rake', :group => [:development, :test]
 
 group :test do
   gem 'rspec'
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 6.0')
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 6.8')
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "< 4")
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || "~> 4.0")
   gem 'uuidtools'


### PR DESCRIPTION
For some reason, `bundle install` in acceptance pipelines is deciding to install Beaker 6.6.0 instead of the 6.8.1 used by the `openvox` agent acceptance suites.

The 6.6.0 version is missing a critical fix that prevents Beaker from mis-classifying `el-10` as `el-1` and falling back to SysV service management commands:

  voxpupuli/beaker@400af53c2

This fails acceptance tests on Alma Linux 10 as that distro does not install the SysV shims by default.

This commit updates the pin from `~>6.0` to `~>6.8` which forces dependency resolution to pick the 6.8.1 version.


(cherry picked from commit bd84ac2c16789ab493e53d4c497b2763ee5f1fa8)

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
