### PR TITLE
More EL-10 Postgres acceptance test fixes

### DIFF
--- a/acceptance/suites/pre_suite/foss/95_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/95_install_pdb.rb
@@ -14,7 +14,7 @@ end
 step 'Update EL postgresql repos' do
   # work around for testing on rhel and the repos on the image not finding the pg packages it needs
   if master.platform =~ /el-/
-    major_version = host.platform.split('-')[1]
+    major_version = master.platform.split('-')[1]
 
     on master, "dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-#{major_version}-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
     on master, "dnf -qy module disable postgresql"

--- a/acceptance/suites/pre_suite/foss/95_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/95_install_pdb.rb
@@ -17,7 +17,9 @@ step 'Update EL postgresql repos' do
     major_version = master.platform.split('-')[1]
 
     on master, "dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-#{major_version}-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
-    on master, "dnf -qy module disable postgresql"
+    # The built-in postgres modules pre-empt the postgresql.org repos.
+    # Modules were introduced in EL 8, and deprecated in EL 10.
+    on master, "dnf -qy module disable postgresql" if %w[8 9].include?(major_version)
   end
 end
 


### PR DESCRIPTION
#### Pull Request (PR) description

This PR contains two more fixes to the EL 10 acceptance tests:

  - A dumb variable naming mistake I made in #356
  - DNF modules are deprecated in EL 10, so the `dnf disable module postgresql` command fails as there are no built-in modules by default. This command is confined to EL 8 and EL 9.