### PR TITLE
switch to Alma 9 / Java 17 / system Ruby

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -96,7 +96,7 @@ jobs:
       - name: setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3' # should match the Ruby used in Dockerfile. Currently Ruby 3.3 from Alma 10
+          ruby-version: '3.3' # should match the Ruby used in Dockerfile. Currently Ruby 3.3 from Alma 9
           bundler-cache: true
       - id: docker-cache
         uses: actions/cache/restore@v5

--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -96,7 +96,7 @@ jobs:
       - name: setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3' # should match the Ruby used in Dockerfile. Currently Ruby 3.3 from Alma 9
+          ruby-version: '3.2' # should match the Ruby used in Dockerfile. Currently Ruby 3.2 from RVM
           bundler-cache: true
       - id: docker-cache
         uses: actions/cache/restore@v5

--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -96,7 +96,7 @@ jobs:
       - name: setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0'
+          ruby-version: '3.3' # should match the Ruby used in Dockerfile. Currently Ruby 3.3 from Alma 10
           bundler-cache: true
       - id: docker-cache
         uses: actions/cache/restore@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,28 +3,26 @@ FROM almalinux:9
 WORKDIR /
 
 RUN dnf install -y --enablerepo=crb \
-    autoconf \
-    automake \
-    bison \
-    bzip2 \
-    cpio \
-    gcc-c++ \
-    git \
-    java-17-openjdk-headless \
-    libffi-devel \
-    libtool \
-    libyaml-devel \
-    make \
-    openssl-devel \
-    patch \
-    readline \
-    readline-devel \
-    rpm-build \
-    ruby \
-    sqlite-devel \
-    wget \
-    zlib \
-    zlib-devel
+  autoconf \
+  automake \
+  bison \
+  bzip2 \
+  gcc-c++ \
+  git \
+  java-17-openjdk \
+  libffi-devel \
+  libtool \
+  libyaml-devel \
+  make \
+  openssl-devel \
+  patch \
+  readline \
+  readline-devel \
+  rpm-build \
+  sqlite-devel \
+  wget \
+  zlib \
+  zlib-devel
 
 # Extract SLES RPM macros to aid in the expansion of macros on SLES
 # Isolate the target SUSE/SLES 15 systemd RPM macros to avoid EL10 host collision
@@ -38,5 +36,10 @@ ADD --chmod=0755 https://raw.githubusercontent.com/technomancy/leiningen/stable/
 RUN git config --global user.email "openvox@voxpupuli.org" && \
     git config --global user.name "Vox Pupuli" && \
     git config --global --add safe.directory /code
+
+RUN wget -q https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer -O- | bash
+
+RUN /bin/bash --login -c 'rbenv install 3.2.11' && \
+    /bin/bash --login -c 'rbenv global 3.2.11'
 
 CMD ["tail", "-f", "/dev/null"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,39 @@
-FROM ruby:4.0-bookworm
+FROM almalinux:9
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      openjdk-17-jdk-headless \
-      rpm \
-    && rm -rf /var/lib/apt/lists/*
+WORKDIR /
 
-RUN wget -q https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -O /usr/local/bin/lein && \
-    chmod a+x /usr/local/bin/lein
+RUN dnf install -y --enablerepo=crb \
+    autoconf \
+    automake \
+    bison \
+    bzip2 \
+    cpio \
+    gcc-c++ \
+    git \
+    java-17-openjdk-headless \
+    libffi-devel \
+    libtool \
+    libyaml-devel \
+    make \
+    openssl-devel \
+    patch \
+    readline \
+    readline-devel \
+    rpm-build \
+    ruby \
+    sqlite-devel \
+    wget \
+    zlib \
+    zlib-devel
+
+# Extract SLES RPM macros to aid in the expansion of macros on SLES
+# Isolate the target SUSE/SLES 15 systemd RPM macros to avoid EL10 host collision
+RUN mkdir -p /opt/suse-rpm-macros && \
+    wget -q https://download.opensuse.org/distribution/leap/15.6/repo/oss/noarch/systemd-rpm-macros-15-150000.7.39.1.noarch.rpm -O /tmp/suse-rpm-macros.rpm && \
+    rpm2cpio /tmp/suse-rpm-macros.rpm | cpio -idmv -D /opt/suse-rpm-macros && \
+    rm /tmp/suse-rpm-macros.rpm
+
+ADD --chmod=0755 https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein /usr/local/bin/lein
 
 RUN git config --global user.email "openvox@voxpupuli.org" && \
     git config --global user.name "Vox Pupuli" && \


### PR DESCRIPTION
- isolate SLES RPM macros in /opt/suse-rpm-macros
  - later on during the ezbake build phase, we'll be able to expand systemd RPM macros properly on SLES