### PR TITLE
Migrate external actions to pinned git commits

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -29,20 +29,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
       - name: setup java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.version }}
       - name: setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: '3.1'
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@13.5
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           lein: latest
       - name: setup gems
@@ -61,20 +61,20 @@ jobs:
         ruby: ['3.1', '3.2', '3.3', '3.4', '4.0']
     steps:
       - name: checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
       - name: setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: setup java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@13.5
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           lein: latest
       - name: setup gems
@@ -89,17 +89,17 @@ jobs:
       pull-requests: write
     steps:
       - name: checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
           fetch-depth: 0 # So we fetch all history and tags and can build non-tagged versions
       - name: setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: '3.2' # should match the Ruby used in Dockerfile. Currently Ruby 3.2 from RVM
           bundler-cache: true
       - id: docker-cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/ezbake-builder.tar
           key: docker-ezbake-${{ hashFiles('Dockerfile') }}
@@ -111,7 +111,7 @@ jobs:
             docker build -t ezbake-builder .
             docker save ezbake-builder -o /tmp/ezbake-builder.tar
           fi
-      - uses: actions/cache/save@v5
+      - uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         if: always() && steps.docker-cache.outputs.cache-hit != 'true'
         with:
           path: /tmp/ezbake-builder.tar
@@ -125,14 +125,14 @@ jobs:
           echo "describe=${DESCRIBE//-/.}" >> $GITHUB_OUTPUT
       - name: Upload build artifacts
         id: upload
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: openvox-server-${{ steps.version.outputs.describe }}.zip
           path: output/
           retention-days: 1 # quite low retention, because the artifacts are quite large
           overwrite: true # overwrite old artifacts if a PR runs again (artifacts are per PR * per project)
       - name: Find existing comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         # Check if the event is not triggered by a fork
         # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks
         if: github.event.pull_request.head.repo.full_name == github.repository
@@ -142,7 +142,7 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: '<!-- build-artifacts -->'
       - name: Add or update comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -158,16 +158,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: setup java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: temurin
           java-version: 17
       - name: checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # newer versions cause lint errors
       # https://github.com/clj-kondo/clj-kondo/releases
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@13.5
+        uses: DeLaGuardo/setup-clojure@4c7a6f613e5089821bb3bb2a33a3ee115578580d # 13.6.1
         with:
           clj-kondo: 2025.02.20
       - name: kondo lint


### PR DESCRIPTION
Generated with:

```
pinact run --verify --update
```

source: https://github.com/suzuki-shunsuke/pinact


(cherry picked from commit 06c9cdb091d253ba1bf57de9c001574fe1e953b9)

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
