### PR TITLE
Update openvox submodule to 8.28.0-11-gaf1cbe7159 on 8.x branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "ruby/puppet"]
 	path = ruby/puppet
 	url = https://github.com/openvoxproject/openvox.git
+	branch = 8.x
 [submodule "ruby/hiera"]
 	path = ruby/hiera
 	url = https://github.com/openvoxproject/hiera.git


### PR DESCRIPTION
#### Pull Request (PR) description

This commit updates the `ruby/puppet` submodule to OpenVoxProject/openvox@af1cbe7159 and sets the tracking branch to `8.x`. This commit carries a fix for a file resource race condition that causes OpenVox Server tests to intermittently fail.

Fixes OpenVoxProject/openvox-server#414.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
