### PR TITLE
Revert resource increase for tests, crash on OutOfMemory error instead

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -55,7 +55,7 @@ jobs:
         run: ./dev-setup
       - name: clojure tests
         run: lein -U ${{ matrix.javaargs }} test ${{ matrix.filter }}
-        timeout-minutes: 120
+        timeout-minutes: 30
 
   rspec-tests:
     name: Rspec Tests - Java ${{ matrix.java }} Ruby ${{ matrix.ruby }}

--- a/project.clj
+++ b/project.clj
@@ -234,7 +234,7 @@
                     ;; use core.async and need more than eight threads to run
                     ;; properly; this setting overrides the default value.  Without
                     ;; it the metrics tests will hang.
-                    :jvm-opts ["-Dclojure.core.async.pool-size=50", "-Xms4g", "-Xmx4g"]
+                    :jvm-opts ["-Dclojure.core.async.pool-size=50"]
                     ;; Use humane test output so you can actually see what the problem is
                     ;; when a test fails.
                     :dependencies [[pjstadig/humane-test-output]]

--- a/project.clj
+++ b/project.clj
@@ -234,7 +234,7 @@
                     ;; use core.async and need more than eight threads to run
                     ;; properly; this setting overrides the default value.  Without
                     ;; it the metrics tests will hang.
-                    :jvm-opts ["-Dclojure.core.async.pool-size=50"]
+                    :jvm-opts ["-Dclojure.core.async.pool-size=50" "-XX:+CrashOnOutOfMemoryError"]
                     ;; Use humane test output so you can actually see what the problem is
                     ;; when a test fails.
                     :dependencies [[pjstadig/humane-test-output]]


### PR DESCRIPTION
#### Pull Request (PR) description

This changeset reverts the increased resource allocation that was given to tests in commit 332b0166310d2f7d0011911da31ddf33375dbac6 as that change had no effect on the `OutOfMemory` error that appeared after upgrading to JRuby 9.4.14.0. Instead, the tests are configured to crash the JVM if an `OutOfMemory` error is thrown so that failure happens fast and with a strong signal.

This change will assist with troubleshooting the memory leak as described in OpenVoxProject/jruby-utils#76 

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
