### PR TITLE
CI: Drop redundant MRI matrix from RSpec tests

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -64,7 +64,11 @@ jobs:
       fail-fast: false
       matrix:
         java: ['21', '25']
-        ruby: ['3.1', '3.2', '3.3', '3.4', '4.0']
+        # The specs always run under the JRuby pinned via jruby-utils
+        # (see Rakefile: lein run -m org.jruby.Main); this MRI only drives
+        # rake and dev-setup, so one version suffices. Match the reference
+        # Ruby used by the build job / Dockerfile.
+        ruby: ['3.3']
     steps:
       - name: checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/Rakefile
+++ b/Rakefile
@@ -185,7 +185,7 @@ namespace :spec do
       PATH='#{TEST_GEMS_DIR}/bin:#{path}' \
       BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
-      #{LEIN_PATH} run -m org.jruby.Main \
+      #{LEIN_PATH} run -m org.jruby.Main --dev \
         -S bundle install --without extra development packaging --path='#{TEST_BUNDLE_DIR}' --retry=3
       CMD
       sh bundle_install
@@ -203,10 +203,14 @@ task :spec, [:rspec_opts] => ["spec:init"] do |t, args|
   ## Line 4 adds all our Ruby source to the JRuby LOAD_PATH
   ## Line 5 runs our rspec wrapper script
   ## <sarcasm-font>dang ole real easy man</sarcasm-font>
+  ## --dev favors fast startup over peak JIT optimization, which is the
+  ## right trade for a short-lived spec-runner process. The server's own
+  ## JRuby pools default to compile-mode :off (jruby-utils), so this also
+  ## better matches production behavior.
   run_rspec_with_jruby = <<-CMD
     BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
     GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
-    #{LEIN_PATH} run -m org.jruby.Main \
+    #{LEIN_PATH} run -m org.jruby.Main --dev \
       -I'#{PUPPET_SERVER_RUBY_SPEC}' -I'#{PUPPET_LIB}' -I'#{FACTER_LIB}' -I'#{PUPPET_SERVER_RUBY_SRC}' \
       ./spec/run_specs.rb #{rspec_opts}
   CMD


### PR DESCRIPTION
#### Pull Request (PR) description
## Run spec JRuby in --dev mode

`rake spec` launches the puppet/puppetserver ruby specs in a single
short-lived JRuby via `lein run -m org.jruby.Main`, which defaults to
compile-mode JIT. `--dev` turns the JIT off, favoring startup time over
peak optimization -- the right trade for a one-shot spec runner, and
consistent with the server's own JRuby pools, which already default to
`compile-mode :off` via jruby-utils. Verified against JRuby 10.0.5.0 that
`org.jruby.Main` accepts `--dev` in-process (compile mode `JIT -> OFF`).

The same flag is applied to the `spec:init` `bundle install`, which runs
under the same JRuby.

Trade-off note: JIT-optimizer-specific behavior is less exercised, but
these specs test openvox-server's ruby code, not JRuby's optimizer --
and production pools run with the JIT off anyway.

## CI: Drop redundant MRI matrix from rspec-tests

The rspec-tests job matrixed over MRI 3.1-4.0, but the specs never run
under that Ruby: `rake spec` executes them inside the JRuby pinned by
jruby-utils (`lein run -m org.jruby.Main`), and `matrix.ruby` only selects
the MRI that runs `rake` and `dev-setup`. All five variants per Java version
were testing the same thing. Keep one MRI (3.3, matching the build job
and Dockerfile reference Ruby), reducing 10 jobs per PR to 2.

If exercising the specs under multiple Ruby *language* versions is ever
wanted, that is controlled by the JRuby version in jruby-utils, not by
this matrix.

*Changes generated by Claude Code*

#### This Pull Request (PR) fixes the following issues
N/A