### PR TITLE
Limit JIT tiering for one-shot CLI subcommands

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -163,6 +163,12 @@
                        :puppet-platform-version 9
                        :java-args ~(str "-Xms2g -Xmx2g "
                                      "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger")
+                       ;; Default JVM args for one-shot CLI subcommands (gem,
+                       ;; irb, ruby). Limiting JIT tiering favors startup time
+                       ;; over peak optimization, which is the right trade for
+                       ;; short-lived processes. Overridable via JAVA_ARGS_CLI
+                       ;; in the service defaults file.
+                       :java-args-cli "-XX:TieredStopAtLevel=1"
                        :create-dirs ["/opt/puppetlabs/server/data/puppetserver/jars"
                                      "/opt/puppetlabs/server/data/puppetserver/yaml"]
                        :repo-target "openvox9"


### PR DESCRIPTION
#### Pull Request (PR) description
The gem, irb, and ruby subcommands boot a full JVM per invocation but live only seconds. Their JRuby already runs with compile-mode :off (the jruby-utils default, shared with the server pools), but the JVM itself was untuned: ezbake's :java-args-cli defaults to an empty string, so these one-shot processes paid full C2 JIT warm-up.

Set -XX:TieredStopAtLevel=1 as the packaged default for JAVA_ARGS_CLI. Measured on an installed 4-core server with 'puppetserver gem list':

  wall clock:  3.00s -> 2.48s  (~17% faster)
  CPU time:    7.34s -> 4.11s  (~44% less)
  max RSS:     420MB -> 298MB  (~29% less)

The service path (JAVA_ARGS) is untouched and keeps full JIT. Operators can still override JAVA_ARGS_CLI in the service defaults file, since ezbake renders it as ${JAVA_ARGS_CLI:-<default>}. The ca and prune subcommands run under the agent's MRI Ruby and are unaffected.

Suggested by @Sharpie in review of openvox-server#427.

Code generated by Claude Code.

#### This Pull Request (PR) fixes the following issues
N/A