### PR TITLE
Upgrade JRuby 9.4.12.1->9.4.15.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -71,7 +71,7 @@
                          [org.openvoxproject/comidi "1.1.3"]
                          [org.openvoxproject/http-client "2.3.1"]
                          [org.openvoxproject/i18n ~i18n-version]
-                         [org.openvoxproject/jruby-utils "5.4.1"]
+                         [org.openvoxproject/jruby-utils "5.5.0"]
                          [org.openvoxproject/kitchensink "3.5.7"]
                          [org.openvoxproject/kitchensink "3.5.7" :classifier "test"]
                          [org.openvoxproject/rbac-client "1.3.0"]

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -11,6 +11,18 @@
   "platformAutomerge": true,
 
   "packageRules": [
+    // The 8.x branch follows jruby-utils 5.x, which tracks JRuby 9.4.
+    // The main branch is free to take up jruby-utils 6.x, which tracks
+    // JRuby 10.0.
+    {
+      "groupName": "jruby updates",
+      "allowedVersions": "<6.0",
+      "matchBaseBranches": "8.x",
+      "matchPackageNames": [
+        "org.openvoxproject:jruby-utils"
+      ]
+    },
+
     // Jackson 2.21.z is the LTS release line for the 2.x series.
     // The Cheshire JSON parser uses Jackson 2.x instead of the
     // newer 3.x release, thus we must stay on a 2.x LTS.

--- a/resources/ext/build-scripts/jruby-stdlib-gem-list.txt
+++ b/resources/ext/build-scripts/jruby-stdlib-gem-list.txt
@@ -1,4 +1,3 @@
-jruby-openssl 0.16.0
 matrix 0.4.3
 minitest 5.26.2
 net-ftp 0.3.9


### PR DESCRIPTION
#### Pull Request (PR) description

This patch set upgrades JRuby to 9.4.15.0.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
