### PR TITLE
ci: fix renovate regex.

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -17,7 +17,7 @@
         "/^resources/ext/build-scripts/.*\\.txt$/"
       ],
       "matchStrings": [
-        "^(?<depName>\\S+)\\s+(?<currentValue>\\S+)\\s*$"
+        "(?:^|\\r\\n|\\r|\\n)(?<depName>\\S+)\\s+(?<currentValue>\\S+)"
       ],
       "datasourceTemplate": "rubygems"
     }


### PR DESCRIPTION
> The regex manager matches are done per-file, not per-line! This means the ^ and $ regex assertions only match the beginning and end of the entire file. If you need to match line boundaries you can use (?:^|\r\n|\r|\n|$).