### PR TITLE
Drop Ubuntu 20.04 and Fedora 42 from EZbake build

### DIFF
--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -15,10 +15,10 @@ require 'tmpdir'
 #   https://github.com/puppetlabs/ezbake/blob/aeb7735a16d2eecd389a6bd9e5c0cfc7c62e61a5/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
 #
 # Note: This is not the canonical list of supported OpenVox platforms. Look at https://github.com/OpenVoxProject/shared-actions/blob/8f4d7e99f5e8a23f48e07124aa9adbb9768fabb9/.github/workflows/build_ezbake.yml#L36-L37
-deb_platforms = ENV['DEB_PLATFORMS'] || 'ubuntu-20.04,ubuntu-22.04,ubuntu-24.04,ubuntu-25.04,ubuntu-25.10,ubuntu-26.04,debian-13'
+deb_platforms = ENV['DEB_PLATFORMS'] || 'ubuntu-22.04,ubuntu-24.04,ubuntu-25.04,ubuntu-25.10,ubuntu-26.04,debian-13'
 @debs = deb_platforms.split(',').map{ |p| "base-#{p.split('-').join}-i386.cow" }.join(' ')
 
-rpm_platforms = ENV['RPM_PLATFORMS'] || 'el-8,el-9,el-10,sles-15,sles-16,amazon-2023,fedora-42,fedora-43,fedora-44'
+rpm_platforms = ENV['RPM_PLATFORMS'] || 'el-8,el-9,el-10,sles-15,sles-16,amazon-2023,fedora-43,fedora-44'
 rpm_fips, rpm_nonfips = rpm_platforms.split(',').partition { |p| p.start_with?('redhatfips') }
 @nonfips_rpms = rpm_nonfips.map{ |p| "pl-#{p}-x86_64" }.join(' ')
 @fips_rpms = rpm_fips.map{ |p| "pl-#{p}-x86_64" }.join(' ')


### PR DESCRIPTION

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description

These are not included in the current `platforms.json` list for the `main` branch defined in the OpenVoxProject/shared-actions repo.


#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
