### PR TITLE
Invert Java version test for "add-opens"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -350,7 +350,7 @@
                   (str "-Xms" (heap-size "1G"))
                   (str "-Xmx" (heap-size "2G"))
                   "-XX:+IgnoreUnrecognizedVMOptions"]
-                 (if (>= 17 (java.lang.Integer/parseInt major))
+                 (if (>= (java.lang.Integer/parseInt major) 17)
                    ["--add-opens" "java.base/sun.nio.ch=ALL-UNNAMED" "--add-opens" "java.base/java.io=ALL-UNNAMED"]
                    [])))
 


### PR DESCRIPTION
The following JVM flags are required when running on Java 17 or newer:

    --add-opens java.base/sun.nio.ch=ALL-UNNAMED
    --add-opens java.base/java.io=ALL-UNNAMED

These are used whenever JRuby has to perform native I/O, such as shelling out to an external process. The bump to JRuby 10 has caused additional dependencies from the OpenVox Gemfile to be picked up, which in turn results in `bundle install` attempting to shell out.

This revealed that the version check for adding these flags was inverted: it activated when the JVM version was less than or equal to Java 17.
