### PR TITLE
acceptance: Run tests against Postgres 17

### DIFF
--- a/acceptance/suites/pre_suite/foss/95_install_pdb.rb
+++ b/acceptance/suites/pre_suite/foss/95_install_pdb.rb
@@ -56,7 +56,7 @@ node default {
     puppetdb_package    => 'openvoxdb',
     manage_firewall     => false,
     manage_package_repo => true,
-    postgres_version    => '14',
+    postgres_version    => '17',
   }
 
   class { 'puppetdb::master::config':


### PR DESCRIPTION


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description

This commit moves the acceptance suite from testing Postgres 14 to testing Postgres 17.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
