### PR TITLE
Release cleanup

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -256,7 +256,7 @@
                                                [org.openvoxproject/puppetserver "9.0.0-beta2-SNAPSHOT"]
                                                [org.openvoxproject/trapperkeeper-webserver]
                                                [org.openvoxproject/trapperkeeper-metrics]]
-                      :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.8.0")]]
+                      :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.9.0")]]
                       :name "puppetserver"}
 
              :ezbake-fips {:dependencies ^:replace [[org.clojure/clojure]
@@ -270,7 +270,7 @@
                                                     [org.openvoxproject/trapperkeeper-webserver]
                                                     [org.openvoxproject/trapperkeeper-metrics]]
                             :uberjar-exclusions [#"^org/bouncycastle/.*"]
-                            :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.8.0")]]
+                            :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.9.0")]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.openvoxproject/trapperkeeper-webserver]]
                        :aot [puppetlabs.trapperkeeper.main

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
 
 ;; If you modify the version manually, run scripts/sync_ezbake_dep.rb to keep
 ;; the ezbake dependency in sync.
-(defproject org.openvoxproject/puppetserver "9.1.0-SNAPSHOT"
+(defproject org.openvoxproject/puppetserver "9.0.0-beta2-SNAPSHOT"
   :description "OpenVox Server"
 
   :license {:name "Apache License, Version 2.0"
@@ -253,7 +253,7 @@
                                                [org.openvoxproject/jruby-utils]
                                                ;; Do not modify this line. It is managed by the release process
                                                ;; via the scripts/sync_ezbake_dep.rb script.
-                                               [org.openvoxproject/puppetserver "9.1.0-SNAPSHOT"]
+                                               [org.openvoxproject/puppetserver "9.0.0-beta2-SNAPSHOT"]
                                                [org.openvoxproject/trapperkeeper-webserver]
                                                [org.openvoxproject/trapperkeeper-metrics]]
                       :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.8.0")]]
@@ -266,7 +266,7 @@
                                                     [org.openvoxproject/jruby-utils]
                                                     ;; Do not modify this line. It is managed by the release process
                                                     ;; via the scripts/sync_ezbake_dep.rb script.
-                                                    [org.openvoxproject/puppetserver "9.1.0-SNAPSHOT"]
+                                                    [org.openvoxproject/puppetserver "9.0.0-beta2-SNAPSHOT"]
                                                     [org.openvoxproject/trapperkeeper-webserver]
                                                     [org.openvoxproject/trapperkeeper-metrics]]
                             :uberjar-exclusions [#"^org/bouncycastle/.*"]

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -15,7 +15,7 @@ require 'tmpdir'
 #   https://github.com/puppetlabs/ezbake/blob/aeb7735a16d2eecd389a6bd9e5c0cfc7c62e61a5/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
 #
 # Note: This is not the canonical list of supported OpenVox platforms. Look at https://github.com/OpenVoxProject/shared-actions/blob/8f4d7e99f5e8a23f48e07124aa9adbb9768fabb9/.github/workflows/build_ezbake.yml#L36-L37
-deb_platforms = ENV['DEB_PLATFORMS'] || 'ubuntu-22.04,ubuntu-24.04,ubuntu-25.04,ubuntu-25.10,ubuntu-26.04,debian-13'
+deb_platforms = ENV['DEB_PLATFORMS'] || 'ubuntu-22.04,ubuntu-24.04,ubuntu-26.04,debian-13'
 @debs = deb_platforms.split(',').map{ |p| "base-#{p.split('-').join}-i386.cow" }.join(' ')
 
 rpm_platforms = ENV['RPM_PLATFORMS'] || 'el-8,el-9,el-10,sles-15,sles-16,amazon-2023,fedora-43,fedora-44'


### PR DESCRIPTION
#### Pull Request (PR) description

This changeset includes a couple of clean-up items from the beta1 release:

  - Set version back to `9.0.0-beta2-SNAPSHOT`
  - Bump EZbake to 2.9.0
  - Remove Ubuntu 25.04 and 25.10 from the list of default EZbake builds

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
