### PR TITLE
Ensure "gem install" works during FIPS builds

### DIFF
--- a/resources/ext/build-scripts/install-vendored-gems.sh
+++ b/resources/ext/build-scripts/install-vendored-gems.sh
@@ -20,7 +20,11 @@ install_gems () {
   # Return early if no gems in file.
   [[ "${#gem_list[@]}" -eq 0 ]] && return
 
-  java -cp ext/classpath-jars/*:puppet-server-release.jar:jruby-9k.jar clojure.main -m puppetlabs.puppetserver.cli.gem --config jruby.conf -- install ${additional_args:+"$additional_args"} --no-document "${gem_list[@]}"
+  # JRuby Gem Install requires the non-FIPS BouncyCastle libraries, and only
+  # the non-FIPS libraries, to be present on the classpath.
+  gem_install_jars=(ext/classpath-jars/{bcpkix,bcprov}-jdk18on-*.jar)
+
+  java -cp "$(IFS=:; echo "${gem_install_jars[*]}"):puppet-server-release.jar" clojure.main -m puppetlabs.puppetserver.cli.gem --config jruby.conf -- install ${additional_args:+"$additional_args"} --no-document "${gem_list[@]}"
 }
 
 SOURCE="${BASH_SOURCE[0]}"


### PR DESCRIPTION
#### Pull Request (PR) description

During EZbake builds of `.rpm` and `.deb` packages, the JRuby "gem install" command is run with a classpath that includes the regular non-FIPS BouncyCastle libraries as this allows `require 'net/https'` to complete successfully. However, the classpath also includes the FIPS-enabled libraries, and having a mixture of both now causes failures.

This commit fixes the issue by adding just the `bcpkix` and `bcprov` libraries to the classpath instead of everything in `ext/classpath-jars/`.

The `jruby-9k.jar` entry is also dropped as JRuby has not been packaged as a separate uberjar for many years.

Ref: jruby/jruby-openssl#361

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
