### PR TITLE
CI: bundle: dont set --path

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -188,6 +188,14 @@ namespace :spec do
       #{LEIN_PATH} run -m org.jruby.Main --dev \
         -S bundle install --without extra development packaging --path='#{TEST_BUNDLE_DIR}' --retry=3
       CMD
+      bundle_path = <<-CMD2
+      PATH='#{TEST_GEMS_DIR}/bin:#{path}' \
+      BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
+      GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
+      #{LEIN_PATH} run -m org.jruby.Main --dev \
+      -S bundle config set path '#{TEST_BUNDLE_DIR}'
+      CMD2
+      sh bundle_path
       sh bundle_install
     end
   end


### PR DESCRIPTION
`--path` is deprecated, so need to call `bundle config set...`

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
