### PR TITLE
CI: dont set path twice & bundle: avoid --without & Drop redundant MRI matrix from rspec-tests

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -58,7 +58,11 @@ jobs:
       fail-fast: false
       matrix:
         java: ['17', '21']
-        ruby: ['3.1', '3.2', '3.3', '3.4', '4.0']
+        # The specs always run under the JRuby pinned via jruby-utils
+        # (see Rakefile: lein run -m org.jruby.Main); this MRI only drives
+        # rake and dev-setup, so one version suffices. Match the reference
+        # Ruby used by the build job / Dockerfile.
+        ruby: ['3.3']
     steps:
       - name: checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/Rakefile
+++ b/Rakefile
@@ -186,7 +186,7 @@ namespace :spec do
       BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
       #{LEIN_PATH} run -m org.jruby.Main \
-        -S bundle install --without extra development packaging --retry=3
+        -S bundle install --retry=3
       CMD
       bundle_path = <<-CMD2
       PATH='#{TEST_GEMS_DIR}/bin:#{path}' \
@@ -195,6 +195,14 @@ namespace :spec do
       #{LEIN_PATH} run -m org.jruby.Main \
       -S bundle config set path '#{TEST_BUNDLE_DIR}'
       CMD2
+      bundle_without = <<-CMD2
+      PATH='#{TEST_GEMS_DIR}/bin:#{path}' \
+      BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
+      GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
+      #{LEIN_PATH} run -m org.jruby.Main --dev \
+      -S bundle config set without extra:development:packaging
+      CMD2
+      sh bundle_without
       sh bundle_path
       sh bundle_install
     end

--- a/Rakefile
+++ b/Rakefile
@@ -186,13 +186,13 @@ namespace :spec do
       BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
       #{LEIN_PATH} run -m org.jruby.Main \
-        -S bundle install --without extra development packaging --path='#{TEST_BUNDLE_DIR}' --retry=3
+        -S bundle install --without extra development packaging --retry=3
       CMD
       bundle_path = <<-CMD2
       PATH='#{TEST_GEMS_DIR}/bin:#{path}' \
       BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
-      #{LEIN_PATH} run -m org.jruby.Main --dev \
+      #{LEIN_PATH} run -m org.jruby.Main \
       -S bundle config set path '#{TEST_BUNDLE_DIR}'
       CMD2
       sh bundle_path

--- a/Rakefile
+++ b/Rakefile
@@ -185,14 +185,14 @@ namespace :spec do
       PATH='#{TEST_GEMS_DIR}/bin:#{path}' \
       BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
-      #{LEIN_PATH} run -m org.jruby.Main \
+      #{LEIN_PATH} run -m org.jruby.Main --dev \
         -S bundle install --retry=3
       CMD
       bundle_path = <<-CMD2
       PATH='#{TEST_GEMS_DIR}/bin:#{path}' \
       BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
       GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
-      #{LEIN_PATH} run -m org.jruby.Main \
+      #{LEIN_PATH} run -m org.jruby.Main --dev \
       -S bundle config set path '#{TEST_BUNDLE_DIR}'
       CMD2
       bundle_without = <<-CMD2
@@ -219,10 +219,14 @@ task :spec, [:rspec_opts] => ["spec:init"] do |t, args|
   ## Line 4 adds all our Ruby source to the JRuby LOAD_PATH
   ## Line 5 runs our rspec wrapper script
   ## <sarcasm-font>dang ole real easy man</sarcasm-font>
+  ## --dev favors fast startup over peak JIT optimization, which is the
+  ## right trade for a short-lived spec-runner process. The server's own
+  ## JRuby pools default to compile-mode :off (jruby-utils), so this also
+  ## better matches production behavior.
   run_rspec_with_jruby = <<-CMD
     BUNDLE_GEMFILE='#{PUPPET_SRC}/Gemfile' \
     GEM_HOME='#{TEST_GEMS_DIR}' GEM_PATH='#{TEST_GEMS_DIR}' \
-    #{LEIN_PATH} run -m org.jruby.Main \
+    #{LEIN_PATH} run -m org.jruby.Main --dev \
       -I'#{PUPPET_SERVER_RUBY_SPEC}' -I'#{PUPPET_LIB}' -I'#{FACTER_LIB}' -I'#{PUPPET_SERVER_RUBY_SRC}' \
       ./spec/run_specs.rb #{rspec_opts}
   CMD


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
