### PR TITLE
Fix Resolv regression when querying IPv6 DNS servers

### DIFF
--- a/src/clj/puppetlabs/puppetserver/cli/gem.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/gem.clj
@@ -5,7 +5,7 @@
 
 (defn gem-run!
   [config args]
-  (let [jruby-config (jruby-puppet-core/initialize-and-create-jruby-config config)]
+  (let [jruby-config (jruby-puppet-core/initialize-jruby-cli-config config)]
     (jruby-core/cli-run! jruby-config "gem" args)))
 
 (defn -main

--- a/src/clj/puppetlabs/puppetserver/cli/irb.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/irb.clj
@@ -5,7 +5,7 @@
 
 (defn irb-run!
   [config args]
-  (let [jruby-config (jruby-puppet-core/initialize-and-create-jruby-config config)]
+  (let [jruby-config (jruby-puppet-core/initialize-jruby-cli-config config)]
     (jruby-core/cli-run! jruby-config "irb" args)))
 
 (defn -main

--- a/src/clj/puppetlabs/puppetserver/cli/ruby.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/ruby.clj
@@ -5,7 +5,7 @@
 
 (defn ruby-run!
   [config args]
-  (let [jruby-config (jruby-puppet-core/initialize-and-create-jruby-config config)]
+  (let [jruby-config (jruby-puppet-core/initialize-jruby-cli-config config)]
     (jruby-core/cli-ruby! jruby-config args)))
 
 (defn -main

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -274,6 +274,28 @@
                                                (:max-requests-per-instance jruby-puppet-config)))]
      (create-jruby-config jruby-puppet-config uninitialized-jruby-config agent-shutdown-fn profiler metrics-service))))
 
+(schema/defn initialize-jruby-cli-config :- jruby-schemas/JRubyConfig
+  "Creates JRuby configuration for the \"CLI\" entrypoints. That is:
+
+     puppetserver gem
+     puppetserver irb
+     puppetserver ruby
+
+   This method exists to load up any monkey-patches that may be required
+   to fix issues in the JRuby runtime."
+  [raw-config :- {:jruby-puppet {schema/Keyword schema/Any}
+                  (schema/optional-key :http-client) {schema/Keyword schema/Any}
+                  schema/Keyword schema/Any}]
+  (assoc-in (initialize-and-create-jruby-config raw-config) [:lifecycle :initialize-scripting-container]
+    (fn [scripting-container config]
+      (let [jruby (jruby-core/default-initialize-scripting-container scripting-container config)]
+        (-> ^org.jruby.RubyInstanceConfig jruby
+            (.getRequiredLibraries)
+            ;; Can be dropped when this upstream bug is fixed:
+            ;;   https://github.com/jruby/jruby/issues/9550
+            (.add "puppet/server/patches/resolv_ipv6_normalization"))
+        jruby))))
+
 (def EnvironmentCacheEntry
   "Represents an environment with each cacheable info service as a key.
   The value for each info service is a map that contains a:

--- a/src/ruby/puppetserver-lib/puppet/server/master.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/master.rb
@@ -17,6 +17,12 @@ require 'puppet/server/settings'
 require 'java'
 require 'timeout'
 
+# Fixes regression in Resolv when using IPv6 DNS servers. Can be
+# dropped when the upstream bug is fixed:
+#
+#   https://github.com/jruby/jruby/issues/9550
+require 'puppet/server/patches/resolv_ipv6_normalization'
+
 ##
 ## This class is a bridge between the puppet ruby code and the java interface
 ## `com.puppetlabs.puppetserver.JRubyPuppet`.  The first `include` line in the class

--- a/src/ruby/puppetserver-lib/puppet/server/patches/resolv_ipv6_normalization.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/patches/resolv_ipv6_normalization.rb
@@ -1,0 +1,40 @@
+require 'resolv'
+require 'socket'
+
+# JRuby's UDPSocket#recvfrom returns uncompressed IPv6 peer addresses
+# ("2001:db8:0:0:0:0:0:1") while Addrinfo#ip_address compresses them
+# ("2001:db8::1"). Resolv::DNS::Requester::UnconnectedUDP keys pending
+# queries with the latter and looks replies up with the former, so with
+# 2+ IPv6 nameservers in resolv.conf every reply is discarded as unsolicited
+# and each lookup hangs for 160 seconds before returning an empty array.
+#
+# Loading this file applies a monkeypatch that restores normalization
+# lost when JRuby 9.4.13.0 reverted to using the upstream Resolv gem
+# instead of carrying a patched version that accounted for issues like
+# this.
+#
+# @see https://github.com/OpenVoxProject/openvox-server/issues/535
+# @see https://github.com/jruby/jruby/pull/4496
+# @see https://github.com/ruby/resolv/commit/5c161804ddef0dcf3c230ae6e5b9be1185861797
+module Puppet
+  module Server
+    module ResolvIPv6Normalization
+      def recv_reply(readable_socks)
+        reply, from = super
+        return [reply, from] unless from.is_a?(Array) && from[0].is_a?(String)
+        return [reply, from] unless from[0].include?(':')
+
+        begin
+          [reply, [Addrinfo.ip(from[0]).ip_address, from[1]]]
+        rescue SocketError, ArgumentError
+          [reply, from]
+        end
+      end
+    end
+  end
+end
+
+# Monkeypatch
+if RUBY_ENGINE == 'jruby' && !Resolv::DNS::Requester::UnconnectedUDP.ancestors.include?(Puppet::Server::ResolvIPv6Normalization)
+  Resolv::DNS::Requester::UnconnectedUDP.prepend(Puppet::Server::ResolvIPv6Normalization)
+end


### PR DESCRIPTION
#### Pull Request (PR) description

JRuby 9.4.13.0 switched back to using the upstream Ruby `resolv` gem
instead of maintaining an in-tree version that carried JRuby-specific
patches. However, this switch lost a JRuby patch that normalized IPv6
addresses during DNS lookups. The result is that queries to IPv6 DNS
servers are sent using compressed addresses (e.g. `2001:db8::1`), while
responses arrive from un-compressed addresses (e.g. `2001:db8:0:0:0:0:0:1`).
This mis-match means that queries to IPv6 servers are never seen as
"answered" and the library returns an empty `[]` response after waiting
for 160 seconds.

This commit fixes the issue by loading a monkey-patch that re-applies
the JRuby fix: responses are normalized through `Addrinfo.ip`, which
compresses the IPv6 address and ensures a match.

Ref: https://github.com/jruby/jruby/issues/9550
Ref: https://github.com/jruby/jruby/pull/4496
Ref: https://github.com/ruby/resolv/commit/5c161804ddef0dcf3c230ae6e5b9be1185861797

#### This Pull Request (PR) fixes the following issues

Fixes OpenVoxProject/openvox-server#535
