### PR TITLE
Restrict filebucket reads to pp_cli_auth certificates

### DIFF
--- a/acceptance/suites/tests/authorization/default_rules.rb
+++ b/acceptance/suites/tests/authorization/default_rules.rb
@@ -139,14 +139,26 @@ with_puppet_running_on(master, {}) do
   end
 
   step 'file_bucket_file endpoint' do
-    # We'd actually need to store a file in the filebucket in order to get
-    # back a 200, but we know that a 500 means we got past authorization
-    curl_authenticated('/puppet/v3/file_bucket_file/md5/123?environment=production') do |stdout|
-      assert_allowed(stdout, 500)
+    # Well-formed sha256 checksum for content that was never stored.
+    sum = 'a' * 64
+    bucket_path = "/puppet/v3/file_bucket_file/sha256/#{sum}?environment=production"
+
+    # Agents are allowed 'head' so they can test whether content is already
+    # stored before uploading it.  We'd actually need to store a file in the
+    # filebucket in order to get back a 200, but we know that a 404 means we got
+    # past authorization.
+    curl_authenticated("#{bucket_path} --head") do |stdout|
+      assert_allowed(stdout, 404)
     end
 
-    curl_unauthenticated('/puppet/v3/file_bucket_file/md5/123?environment=production') do |stdout|
-      assert_denied(stdout, /\/puppet\/v3\/file_bucket_file\/md5\/123 \(method :get\)/)
+    # Reading content back out is restricted to certificates carrying the
+    # pp_cli_auth extension, which an ordinary agent certificate does not have.
+    curl_authenticated(bucket_path) do |stdout|
+      assert_denied(stdout, /\/puppet\/v3\/file_bucket_file\/sha256\/#{sum} \(method :get\)/)
+    end
+
+    curl_unauthenticated(bucket_path) do |stdout|
+      assert_denied(stdout, /\/puppet\/v3\/file_bucket_file\/sha256\/#{sum} \(method :get\)/)
     end
   end
 

--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -200,17 +200,41 @@ authorization: {
             name: "puppetlabs environments"
         },
         {
-            # Allow nodes to access all file_bucket_files.  Note that access for
-            # the 'delete' method is forbidden by Puppet regardless of the
-            # configuration of this rule.
+            # Allow nodes to store content in the filebucket.  Agents need 'head'
+            # to test whether content is already stored and 'put' to store it;
+            # they never read content back out.  Note that access for the 'delete'
+            # method is forbidden by Puppet regardless of the configuration of
+            # this rule.
             match-request: {
                 path: "/puppet/v3/file_bucket_file"
                 type: path
-                method: [get, head, post, put]
+                method: [head, put]
             }
             allow: "*"
             sort-order: 500
             name: "puppetlabs file bucket file"
+        },
+        {
+            # Reading content back out of the filebucket is an administrative
+            # operation, so it is restricted to the CLI rather than granted to
+            # every agent.  A central filebucket is shared by every node that
+            # backs up to it, and content is addressed only by checksum with no
+            # record of which node submitted it, so any certificate allowed to
+            # read here can retrieve content backed up by any node.  Sites that
+            # restore remotely with a different administrative certificate should
+            # add a rule of their own rather than widening this one.
+            match-request: {
+                path: "/puppet/v3/file_bucket_file"
+                type: path
+                method: [get, post]
+            }
+            allow: {
+               extensions: {
+                   pp_cli_auth: "true"
+               }
+            }
+            sort-order: 500
+            name: "puppetlabs file bucket file read"
         },
         {
             # Allow nodes to access all file_content.  Note that access for the


### PR DESCRIPTION
#### Pull Request (PR) description
The default auth.conf granted every authenticated certificate get, head, post and put on /puppet/v3/file_bucket_file. A central filebucket is shared by every node that backs up to it, and content is addressed only by checksum with no record of which node submitted it, so that rule let any agent retrieve content backed up by any other node. Every other endpoint serving node-private data is scoped per certname: catalog, node and facts use allow: "$1", and report has no get route at all.

Split the rule by method. Agents keep head and put, which is all they need to store backups, and reads move behind the pp_cli_auth extension already used to gate the CA administrative endpoints.

This is a breaking change for sites that restore or diff remotely using an ordinary agent certificate. Those sites should add a rule of their own for the administrative certname rather than widening the shipped rule.

_Generated by Claude Code_

#### This Pull Request (PR) fixes the following issues
N/A