### PR TITLE
openvox-agent: require 9.0.0~beta2

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -7,7 +7,7 @@
 ezbake: {
    pe: {}
    foss: {
-      redhat: { dependencies: ["openvox-agent >= 9.0.0~beta1"]
+      redhat: { dependencies: ["openvox-agent >= 9.0.0~beta2"]
               # we could add additional packages here
               # build-dependencies: [""],
               # Install some gems
@@ -35,7 +35,7 @@ ezbake: {
                ]
              }
 
-      debian: { dependencies: ["openvox-agent (>= 9.0.0~beta1)"]
+      debian: { dependencies: ["openvox-agent (>= 9.0.0~beta2)"]
                 # we could add additional packages here
                 # build-dependencies: [""],
                 install: ["bash ./ext/build-scripts/install-vendored-gems.sh"]


### PR DESCRIPTION
This is required because it ships openfact 6 and concurrent-ruby 1.3.8. in openvox-server, we also use concurrent-ruby 1.3.8: https://github.com/OpenVoxProject/openvox-server/pull/497

and we updated openvoxserver-ca, which now allows openfact 6 as well: https://github.com/OpenVoxProject/openvox-server/pull/546

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
