### PR TITLE
Fix the report authorization test's is_pe? misfire

### DIFF
--- a/acceptance/suites/tests/authorization/default_rules.rb
+++ b/acceptance/suites/tests/authorization/default_rules.rb
@@ -98,15 +98,14 @@ with_puppet_running_on(master, {}) do
       assert_allowed(stdout)
     end
 
-    # In PE, the master (specifically the orchestrator)
-    # is allowed to make report submissions on behalf of
-    # other nodes
+    # Nodes may submit only their own reports (allow: "$1"); submitting on
+    # behalf of other nodes was a PE orchestrator capability that OpenVox
+    # does not have. Note: this must not be guarded on master.is_pe? --
+    # this suite's beaker options do not set a host type, and beaker's
+    # default type is 'pe', which made is_pe? return true on FOSS hosts
+    # and select the wrong assertion.
     curl_authenticated(report_query('notme')) do |stdout|
-      if master.is_pe?
-        assert_allowed(stdout)
-      else
-        assert_denied(stdout, /\/puppet\/v3\/report\/notme \(method :put\)/)
-      end
+      assert_denied(stdout, /\/puppet\/v3\/report\/notme \(method :put\)/)
     end
 
     curl_unauthenticated(report_query(masterfqdn)) do |stdout|


### PR DESCRIPTION
#### Pull Request (PR) description
The report/notme step asserted that the primary may submit reports on behalf of other nodes when master.is_pe? is true. This suite's beaker options do not set a host type, and beaker's default type is 'pe', so is_pe? returned true on every FOSS host and selected the PE assertion -- which the shipped allow: "$1" report rule correctly rejects with 403. This is the step where default_rules.rb actually failed in acceptance run 31098859281, before the filebucket assertions were ever reached.

OpenVox has no PE edition, so drop the PE arm and assert the denial unconditionally, with a comment warning against reintroducing is_pe? guards while the suite's host type is unset.

Verified on a local beaker rig against openvox-server 9.0.0~beta4: the unmodified test fails at report/notme exactly as in the pipeline; with this commit plus the filebucket fix in #556, default_rules.rb passes end to end (including the new agent-cert filebucket denial and primary-cert 404 assertions).

_Generated by Claude Code_

#### This Pull Request (PR) fixes the following issues
N/A