### PR TITLE
Fall back to the vendored PEM CA bundle for the system trust store

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/config_spec.rb
@@ -42,11 +42,23 @@ describe Puppet::Server::Config do
       end
     end
 
+    it "falls back to the vendored PEM CA bundle when the keystore is absent" do
+      stub_const('Puppet::Server::Config::PUPPET_KEYSTORE_LOCATION',
+                 'spec/fixtures/does-not-exist')
+      stub_const('Puppet::Server::Config::PUPPET_CA_BUNDLE_LOCATION',
+                 'spec/fixtures/ca-cert.pem')
+
+      expect(Puppet).not_to receive(:warning)
+
+      ssl_context = Puppet::Server::Config.puppet_and_system_ssl_context
+      expect(ssl_context).to be_a_kind_of(Java::JavaxNetSsl::SSLContext)
+    end
+
     it "warns if :ssl_trust_store is set but not readable" do
       Puppet[:ssl_trust_store] = "spec/fixtures/foo.pem"
       allow(File).to receive(:exist?).and_return(false)
 
-      expect(Puppet).to receive(:warning).with(/Could not find OpenVox-vendored keystore/)
+      expect(Puppet).to receive(:warning).with(/Could not find an OpenVox-vendored trust store/)
       expect(Puppet).to receive(:warning).with(/The 'ssl_trust_store' setting does not refer to a file/)
 
       Puppet::Server::Config.puppet_and_system_ssl_context

--- a/src/ruby/puppetserver-lib/puppet/server/config.rb
+++ b/src/ruby/puppetserver-lib/puppet/server/config.rb
@@ -19,6 +19,7 @@ java_import java.security.KeyStore
 
 class Puppet::Server::Config
   PUPPET_KEYSTORE_LOCATION = '/opt/puppetlabs/puppet/ssl/puppet-cacerts'
+  PUPPET_CA_BUNDLE_LOCATION = '/opt/puppetlabs/puppet/ssl/cert.pem'
   CERT_REGEX = /.*-----BEGIN CERTIFICATE-----.*/
 
   def self.initialize_puppet_server(puppet_server_config)
@@ -82,8 +83,16 @@ class Puppet::Server::Config
     truststore = stores['truststore']
     if File.exist?(PUPPET_KEYSTORE_LOCATION)
       associate_entries(truststore, PUPPET_KEYSTORE_LOCATION)
+    elsif File.exist?(PUPPET_CA_BUNDLE_LOCATION)
+      # puppet-runtime stopped shipping the Java keystore form of the
+      # vendored CA bundle (puppet-runtime@066fd48); load the PEM bundle
+      # it still ships instead.
+      SSLUtils.associateCertsFromReader(
+        truststore,
+        'openvox_vendored_ca_bundle',
+        FileReader.new(PUPPET_CA_BUNDLE_LOCATION))
     else
-      Puppet.warning("Could not find OpenVox-vendored keystore at '#{PUPPET_KEYSTORE_LOCATION}'")
+      Puppet.warning("Could not find an OpenVox-vendored trust store at '#{PUPPET_KEYSTORE_LOCATION}' or '#{PUPPET_CA_BUNDLE_LOCATION}'")
     end
 
     if additional_store_location = Puppet[:ssl_trust_store]


### PR DESCRIPTION
#### Pull Request (PR) description
`include_system_store` requests from the server (report processors posting to external HTTPS endpoints, and any `Puppet.runtime[:http]` caller passing the option) stopped trusting publicly-signed certificates in the 9.0.0 betas, failing with PKIX path building errors. This is what broke `acceptance/suites/tests/https/client_may_use_external_cert_chains.rb` on all platforms in acceptance run [31098859281](https://github.com/OpenVoxProject/acceptance-pipelines/actions/runs/31098859281).

Root cause: `Puppet::Server::Config.load_puppet_and_system_ssl_context` builds the system trust by merging a vendored Java keystore from `/opt/puppetlabs/puppet/ssl/puppet-cacerts`, and puppet-runtime deliberately stopped shipping that keystore for the 9.x agent ([puppet-runtime@066fd48](https://github.com/OpenVoxProject/puppet-runtime/commit/066fd48df6232ed9aeda1582eac53153752d6beb), on the reasonable suspicion it was an unused PE-era artifact -- OpenVox does not package Java). The server was its one consumer; with the file absent the context silently degrades to puppet-CA-only trust with a single warning.

Fall back to the PEM CA bundle the runtime still ships at `/opt/puppetlabs/puppet/ssl/cert.pem`, loaded through the same SSLUtils reader already used for the `ssl_trust_store` setting. The keystore is still preferred when present, so 8.x-era agents are unaffected. Trust content is identical either way (both forms are generated from the same Mozilla bundle).

Verified against openvox-server `9.0.0~beta4` with the `9.0.0~beta2` agent on a local beaker rig: the isolated reproduction (puppetserver ruby fetching https://voxpupuli.org with `include_system_store: true`) fails with PKIX before and returns 200 after, and the full `client_may_use_external_cert_chains.rb` acceptance test passes with the patched jar.

Longer term this pairs with [openvox#554](https://github.com/OpenVoxProject/openvox/issues/554) (stop bundling CA certificates): when that lands, this method should grow a further fallback to the system trust anchors. This change keeps 9.0 compatible with the trust behavior 8.x shipped.

_Generated by Claude Code_

#### This Pull Request (PR) fixes the following issues
N/A