### PR TITLE
Add support for building on different ezbake versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,12 @@ on:
           Branch/tag from ezbake that will be used for openvoxdb/server builds.
         type: string
         default: 'main'
-      ezbake-ver:
-        description: 'The version specified in project.clj in the given ezbake-ref. Will default to the version found in project.clj in this repo if not specified.'
+      ezbake-2-ver:
+        description: 'The version specified in project.clj in the given ezbake-ref. Will default to the version 2.x. Used for distros with systemd 252 or older'
+        type: string
+        required: false
+      ezbake-4-ver:
+        description: 'The version specified in project.clj in the given ezbake-ref. Will default to the version 4.x. Used for distros with systemd 253 or newer. Only used for openvox9+'
         type: string
         required: false
 
@@ -46,12 +50,14 @@ permissions:
 
 jobs:
   build:
-    uses: 'openvoxproject/shared-actions/.github/workflows/build_ezbake.yml@main'
+    name: Build OpenVox-Server ${{ inputs.ref }}
+    uses: 'openvoxproject/shared-actions/.github/workflows/build_ezbake.yml@ezbake4'
     with:
       branch: ${{ inputs.branch }}
       ref: ${{ inputs.ref }}
       deb_platform_list: ${{ inputs.deb_platform_list }}
       rpm_platform_list: ${{ inputs.rpm_platform_list }}
       ezbake-ref: ${{ inputs.ezbake-ref }}
-      ezbake-ver: ${{ inputs.ezbake-ver }}
+      ezbake-2-ver: ${{ inputs.ezbake-2-ver }}
+      ezbake-4-ver: ${{ inputs.ezbake-4-ver }}
     secrets: inherit

--- a/.github/workflows/build_fips.yml
+++ b/.github/workflows/build_fips.yml
@@ -30,7 +30,7 @@ on:
         type: string
         default: 'main'
       ezbake-ver:
-        description: 'The version specified in project.clj in the given ezbake-ref. Will default to the version found in project.clj in this repo if not specified.'
+        description: 'The version specified in project.clj in the given ezbake-ref. Will default to the version 2.x. Used for distros with systemd 252 or older'
         type: string
         required: false
 
@@ -39,7 +39,8 @@ permissions:
 
 jobs:
   build:
-    uses: 'openvoxproject/shared-actions/.github/workflows/build_ezbake_fips.yml@main'
+    name: Build OpenVox-Server ${{ inputs.ref }}
+    uses: 'openvoxproject/shared-actions/.github/workflows/build_ezbake_fips.yml@ezbake4'
     with:
       branch: ${{ inputs.branch }}
       ref: ${{ inputs.ref }}

--- a/acceptance/suites/tests/00_smoke/systemd_service_type.rb
+++ b/acceptance/suites/tests/00_smoke/systemd_service_type.rb
@@ -1,0 +1,25 @@
+test_name 'Validate puppetserver systemd unit Type for platform'
+
+skip_test 'No primary node to validate puppetserver service type on' unless master
+
+variant, version, _, _ = master['platform'].to_array
+platform = "#{variant}-#{version}"
+
+# Beaker normalizes the RHEL-family guests to el-* platform names.
+# These legacy OpenVox 9.x acceptance OSes still use Type=forking.
+forking_platforms = %w[
+  el-8
+  el-9
+  ubuntu-2204
+].freeze
+
+expected_type = forking_platforms.include?(platform) ? 'forking' : 'notify-reload'
+
+step "Validate Type= for #{platform} (expected #{expected_type})" do
+  on(master, 'systemctl cat puppetserver.service')
+
+  type_result = on(master, 'systemctl show --property Type --value puppetserver.service')
+  actual_type = type_result.stdout.strip
+
+  assert_equal(expected_type, actual_type, "Unexpected systemd service Type for #{platform}. Expected #{expected_type}, got #{actual_type}")
+end


### PR DESCRIPTION
We have a few conditions:
* FIPS openvox 8 always uses ezbake 2
* FIPS openvox 9 always uses ezbake 2
* non-fips server 8 always uses ezbake 2
* non-fips server 9 uses ezbake 2 on OSes with systemd < 253
* non-fips server 9 uses ezbake 4 on OSes with systemd >= 253

The correct ezbake version comes from platform.json in the
shared-actions repo. To keep things "simple", the FIPS workflow only
takes one ezbake version as input. No FIPS OS has systemd >= 253 at the
moment.