### PR TITLE
Add missing JRuby security flags for Java 21+

### DIFF
--- a/resources/ext/cli_defaults/cli-defaults.sh.erb
+++ b/resources/ext/cli_defaults/cli-defaults.sh.erb
@@ -7,16 +7,14 @@ fi
 java_version=$($JAVA_BIN -version 2>&1 | head -1 | awk -F\" '{ print $2 }')
 java_major_version=$(echo $java_version | awk -F. '{ print $1 }')
 
-if [[ $java_major_version -ge 17 ]]; then
+if [[ $java_major_version -ge 21 ]]; then
 
-	echo $JAVA_ARGS | grep "add-opens" &>/dev/null
-	if [[ 0 -ne $? ]]; then
-		export JAVA_ARGS="--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED ${JAVA_ARGS}"
+	if ! grep -Eq 'add-opens|enable-native-access' <<<"$JAVA_ARGS"; then
+		export JAVA_ARGS="--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --enable-native-access=ALL-UNNAMED ${JAVA_ARGS}"
 	fi
 
-	echo $JAVA_ARGS_CLI | grep "add-opens" &>/dev/null
-	if [[ 0 -ne $? ]]; then
-		export JAVA_ARGS_CLI="--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED ${JAVA_ARGS_CLI}"
+	if ! grep -Eq 'add-opens|enable-native-access' <<<"$JAVA_ARGS_CLI"; then
+		export JAVA_ARGS_CLI="--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --enable-native-access=ALL-UNNAMED ${JAVA_ARGS_CLI}"
 	fi
 fi
 


### PR DESCRIPTION
- Add --enable-native-access=ALL-UNNAMED for Java 21+ native access
- Resolves warnings about restricted methods in java.lang.System::load
- Enables proper operation of 'puppetserver gem list'

Fixes #609