### PR TITLE
Use StandardErrorLogger for ruby subcommands

### DIFF
--- a/src/clj/puppetlabs/puppetserver/cli/subcommand.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/subcommand.clj
@@ -4,6 +4,15 @@
             [puppetlabs.trapperkeeper.config :as tk-config]
             [puppetlabs.i18n.core :as i18n]))
 
+;;; Set the default logger used by ruby, gem, irb, and other subcommands to
+;;; the same class used by JRuby binaries of the same name. This pre-empts
+;;; the SLF4J logger set by jruby-utils, but still allows overrides via explicit
+;;; -D flags in JAVA_ARGS.
+#_{:clj-kondo/ignore [:unused-private-var]}
+(defonce ^:private set-cli-logger-default
+  (doto (System/getProperties)
+    (.putIfAbsent "jruby.logger.class" "org.jruby.util.log.StandardErrorLogger")))
+
 (defn parse-cli-args!
   "Parses the command-line arguments using `puppetlabs.kitchensink.core/cli!`.
    Required arguments:


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvox-server. The packages will be
stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archive will be linked at the bottom. It's
always named openvox-server-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description

Commit c320167385c5c38b1d845833cfc69319e0794f55 bumped the jruby-utils dependency to 7.0.3. This version defaults the JRuby logger class to com.puppetlabs.jruby_utils.jruby.Slf4jLogger when the library is loaded. This logger ends up being backed by Logback when the application is running.

The JRuby cli subcommands, `puppetserver gem`, `puppetserver ruby`, and `puppetserver irb`, do not load any Logback configuration and thus end up with the default of DEBUG logging. This commit fixes the resulting noise by setting the default logger for these subcommands back to org.jruby.util.log.StandardErrorLogger.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
