### PR TITLE
Update to EZbake 4.1.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -256,7 +256,7 @@
                                                [org.openvoxproject/puppetserver "9.1.0-SNAPSHOT"]
                                                [org.openvoxproject/trapperkeeper-webserver]
                                                [org.openvoxproject/trapperkeeper-metrics]]
-                      :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.9.1")]]
+                      :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "4.1.0")]]
                       :name "puppetserver"}
 
              :ezbake-fips {:dependencies ^:replace [[org.clojure/clojure]
@@ -270,7 +270,7 @@
                                                     [org.openvoxproject/trapperkeeper-webserver]
                                                     [org.openvoxproject/trapperkeeper-metrics]]
                             :uberjar-exclusions [#"^org/bouncycastle/.*"]
-                            :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "2.9.1")]]
+                            :plugins [[org.openvoxproject/lein-ezbake ~(or (System/getenv "EZBAKE_VERSION") "4.1.0")]]
                       :name "puppetserver"}
              :uberjar {:dependencies [[org.openvoxproject/trapperkeeper-webserver]]
                        :aot [puppetlabs.trapperkeeper.main

--- a/project.clj
+++ b/project.clj
@@ -163,6 +163,9 @@
                        :puppet-platform-version 9
                        :java-args ~(str "-Xms2g -Xmx2g "
                                      "-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger")
+                       :java-args-dist ~(str "--add-opens java.base/sun.nio.ch=ALL-UNNAMED "
+                                             "--add-opens java.base/java.io=ALL-UNNAMED "
+                                             "--enable-native-access=ALL-UNNAMED")
                        :create-dirs ["/opt/puppetlabs/server/data/puppetserver/jars"
                                      "/opt/puppetlabs/server/data/puppetserver/yaml"]
                        :repo-target "openvox9"

--- a/resources/ext/cli_defaults/cli-defaults.sh.erb
+++ b/resources/ext/cli_defaults/cli-defaults.sh.erb
@@ -10,11 +10,11 @@ java_major_version=$(echo $java_version | awk -F. '{ print $1 }')
 if [[ $java_major_version -ge 21 ]]; then
 
 	if ! grep -Eq 'add-opens|enable-native-access' <<<"$JAVA_ARGS"; then
-		export JAVA_ARGS="--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --enable-native-access=ALL-UNNAMED ${JAVA_ARGS}"
+		export JAVA_ARGS="<%= EZBake::Config[:java_args_dist] %> ${JAVA_ARGS}"
 	fi
 
 	if ! grep -Eq 'add-opens|enable-native-access' <<<"$JAVA_ARGS_CLI"; then
-		export JAVA_ARGS_CLI="--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --enable-native-access=ALL-UNNAMED ${JAVA_ARGS_CLI}"
+		export JAVA_ARGS_CLI="<%= EZBake::Config[:java_args_dist] %> ${JAVA_ARGS_CLI}"
 	fi
 fi
 


### PR DESCRIPTION
#### Pull Request (PR) description

This PR switches OpenVox Server over to building under EZbake 4.1.0. This change drops the `puppetserver start` and `puppetserver stop` sub-commands and instead runs the process directly from `ExecStart` in the SystemD unit.

`puppetserver reload` is preserved for platforms where the SystemD version is older than 253: EL 8, EL 9, Amazon 2023, SLES 15, and Ubuntu 22.04. All other platforms use `Type=notify-reload`.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
